### PR TITLE
chore(i18n): use context for translations

### DIFF
--- a/src/components/Blocks/index.tsx
+++ b/src/components/Blocks/index.tsx
@@ -1,27 +1,28 @@
 import * as React from "react";
+import { useTranslations } from "../../utils/use-translation";
 import Block from "./block";
 
 type EthBlocksPros = {
-  Data?: Data;
   currentBlockNr: number;
 };
-const EthBlocks: React.FC<EthBlocksPros> = ({ currentBlockNr, Data }) => {
-  const remamingBlocks = Number(Data.countdownNr) - currentBlockNr;
+const EthBlocks: React.FC<EthBlocksPros> = ({ currentBlockNr }) => {
+  const { translations: t } = useTranslations();
+  const remamingBlocks = Number(t.countdownNr) - currentBlockNr;
   return (
     <>
       <div className="sm:flex sm:justify-between md:justify-start sm:content-center w-auto">
         <Block
-          title={Data.title_countdown}
-          currentBlockNr={Number(Data.countdownNr)}
+          title={t.title_countdown}
+          currentBlockNr={Number(t.countdownNr)}
           isHas
         />
         <Block
-          title={Data.title_current_block}
+          title={t.title_current_block}
           currentBlockNr={currentBlockNr}
           isHas
         />
         <Block
-          title={Data.title_remaning_block}
+          title={t.title_remaning_block}
           currentBlockNr={remamingBlocks}
           isHas={false}
         />

--- a/src/components/ComingSoon/index.tsx
+++ b/src/components/ComingSoon/index.tsx
@@ -4,6 +4,7 @@ import EthBlocks from "../Blocks";
 import CountDown from "../CountDown/index";
 import TwitterCommunity from "../TwitterCommunity";
 import EthLogo from "../../assets/ethereum-ultra-sound-bat.svg";
+import { useTranslations } from "../../utils/use-translation";
 
 const fetcher = (url: string) =>
   fetch(url, {
@@ -16,7 +17,8 @@ const fetcher = (url: string) =>
     }),
   }).then((r) => r.json());
 
-const ComingSoon: React.FC<{ Data?: Data }> = ({ Data }) => {
+const ComingSoon: React.FC<{}> = () => {
+  const { translations: t } = useTranslations();
   const { data } = useSWR(
     "https://eth-mainnet.alchemyapi.io/v2/H74MQLJkSLBJDyaDS2kyH7bXIBvjiTVe",
     fetcher,
@@ -34,10 +36,10 @@ const ComingSoon: React.FC<{ Data?: Data }> = ({ Data }) => {
             <img
               className="text-center m-auto mb-8"
               src={EthLogo}
-              alt={Data.title}
+              alt={t.title}
             />
             <h1 className="text-white font-extralight text-2xl md:text-3xl xl:text-41xl text-center mb-16">
-              {Data.main_title}
+              {t.main_title}
             </h1>
           </div>
           <div className="flex">
@@ -48,14 +50,13 @@ const ComingSoon: React.FC<{ Data?: Data }> = ({ Data }) => {
           <div className="flex">
             <div className="w-full md:w-5/6 lg:w-3/6 md:m-auto px-4 md:px-0">
               <EthBlocks
-                Data={Data}
                 currentBlockNr={currentBlockNumber && currentBlockNumber}
               />
             </div>
           </div>
           <div className="flex px-4 md:px-0 py-8 md:py-40">
             <div className="w-full md:w-5/6 lg:w-2/3 md:m-auto relative">
-              <TwitterCommunity Data={Data} />
+              <TwitterCommunity />
             </div>
           </div>
         </div>

--- a/src/components/Landing/Intro.tsx
+++ b/src/components/Landing/Intro.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import Twemoji from "../Twemoji";
 import Timeline from "./timeline";
 
-const Intro: React.FC<{ Data?: Data }> = () => {
+const Intro: React.FC<{}> = () => {
   return (
     <>
       <div className="flex flex-wrap justify-center content-center h-screen-90">

--- a/src/components/Landing/index.tsx
+++ b/src/components/Landing/index.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 import Navigation from "../Navigation";
 import Intro from "./Intro";
 
-const LandingPage: React.FC<{ Data?: Data }> = ({ Data }) => {
+const LandingPage: React.FC<{}> = () => {
   return (
     <>
       <div className="wrapper bg-blue-midnightexpress">
         <div className="container m-auto">
-          <Navigation Data={Data} />
-          <Intro Data={Data} />
+          <Navigation />
+          <Intro />
         </div>
       </div>
     </>

--- a/src/components/Landing/timeline.tsx
+++ b/src/components/Landing/timeline.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const Timeline: React.FC<{ Data?: Data }> = () => {
+const Timeline: React.FC<{}> = () => {
   return (
     <>
       <div className="flex flex-wrap justify-center content-end">

--- a/src/components/Layout /index.tsx
+++ b/src/components/Layout /index.tsx
@@ -4,10 +4,9 @@ import Navigation from "../Navigation/index";
 type LayoutProps = {
   children: React.ReactNode;
   className?: string;
-  Data?: Data;
 };
 
-const Layout: NextPage<LayoutProps> = ({ children, className, Data }) => {
+const Layout: NextPage<LayoutProps> = ({ children, className }) => {
   const customClass =
     className !== undefined && className.length >= 0
       ? `wrapper bg-blue-midnightexpress ${className}`
@@ -17,7 +16,7 @@ const Layout: NextPage<LayoutProps> = ({ children, className, Data }) => {
     <>
       <div className={customClass}>
         <div className="container m-auto">
-          <Navigation Data={Data} />
+          <Navigation />
           {children}
         </div>
       </div>

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import Link from "next/link";
 import EthLogo from "../../assets/ethereum-logo-2014-5.svg";
+import { useTranslations } from "../../utils/use-translation";
 
-const Navigation: React.FC<{ Data?: Data }> = ({ Data }) => {
+const Navigation: React.FC<{}> = () => {
+  const { translations: t } = useTranslations();
   const [navbarOpen, setNavbarOpen] = React.useState(false);
   return (
     <>
@@ -10,7 +12,7 @@ const Navigation: React.FC<{ Data?: Data }> = ({ Data }) => {
         <div className="container px-4 mx-auto flex flex-wrap items-center justify-between">
           <div className="w-full relative flex justify-between lg:w-auto lg:static lg:block lg:justify-start">
             <Link href="/">
-              <img src={EthLogo} alt={Data.title} />
+              <img src={EthLogo} alt={t.title} />
             </Link>
             <button
               className="text-white cursor-pointer text-xl leading-none px-3 py-1 border border-solid border-white rounded bg-transparent block lg:hidden outline-none focus:outline-none"

--- a/src/components/TwitterCommunity/ProfileTooltip.tsx
+++ b/src/components/TwitterCommunity/ProfileTooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import twemoji from "twemoji";
 import AvatarImg from "../../assets/avatar.webp";
+import { useTranslations } from "../../utils/use-translation";
 import { followerCountConvert } from "../Helpers/helper";
 
 type ProfileTooltipProps = {
@@ -12,13 +13,9 @@ type ProfileTooltipProps = {
     bio: string;
     followersCount: number;
   };
-  Data?: Data;
 };
-const ProfileTooltip: React.FC<ProfileTooltipProps> = ({
-  children,
-  item,
-  Data,
-}) => {
+const ProfileTooltip: React.FC<ProfileTooltipProps> = ({ children, item }) => {
+  const { translations: t } = useTranslations();
   function imageErrorHandler(e: React.SyntheticEvent<HTMLImageElement, Event>) {
     const el = e.target as HTMLImageElement;
     el.onerror = null;
@@ -63,7 +60,7 @@ const ProfileTooltip: React.FC<ProfileTooltipProps> = ({
             }}
           />
           <p className="text-xs text-blue-spindle text-left font-light uppercase mb-0">
-            {Data.profile_follower}
+            {t.profile_follower}
           </p>
           <p className="text-white text-left font-light text-2xl">
             {followerCountConvert(item.followersCount)}

--- a/src/components/TwitterCommunity/TwitterProfile.tsx
+++ b/src/components/TwitterCommunity/TwitterProfile.tsx
@@ -3,13 +3,9 @@ import AvatarImg from "../../assets/avatar.webp";
 import ProfileTooltip from "./ProfileTooltip";
 
 type TwitterProfilePros = {
-  Data?: Data;
   profileList: TwitterProfile[];
 };
-const TwitterProfile: React.FC<TwitterProfilePros> = ({
-  Data,
-  profileList,
-}) => {
+const TwitterProfile: React.FC<TwitterProfilePros> = ({ profileList }) => {
   function imageErrorHandler(e: React.SyntheticEvent<HTMLImageElement, Event>) {
     const el = e.target as HTMLImageElement;
     el.onerror = null;
@@ -23,7 +19,7 @@ const TwitterProfile: React.FC<TwitterProfilePros> = ({
             .slice(0, 60)
             .map((item: TwitterProfile, index: number) => (
               <div key={index} className="m-2 w-10 h-10">
-                <ProfileTooltip item={item} Data={Data}>
+                <ProfileTooltip item={item}>
                   {window.matchMedia("(min-width: 1024px)").matches ? (
                     <a
                       target="_blank"

--- a/src/components/TwitterCommunity/index.tsx
+++ b/src/components/TwitterCommunity/index.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
-import TwitterProfile from "./TwitterProfile";
 import useSWR from "swr";
 import twemoji from "twemoji";
+import { useTranslations } from "../../utils/use-translation";
+import TwitterProfile from "./TwitterProfile";
 
-type TwitterCommunityPros = {
-  Data?: Data;
-};
+type TwitterCommunityPros = {};
 const fetcher = (url: string) =>
   fetch(url, {
     method: "GET",
@@ -14,7 +13,9 @@ const fetcher = (url: string) =>
       "Content-Type": "application/json",
     },
   }).then((r) => r.json());
-const TwitterCommunity: React.FC<TwitterCommunityPros> = ({ Data }) => {
+
+const TwitterCommunity: React.FC<TwitterCommunityPros> = () => {
+  const { translations: t } = useTranslations();
   const [isCopied, setIsCopied] = React.useState<boolean>(false);
   const [tool, setTool] = React.useState(false);
   const { data } = useSWR(
@@ -33,8 +34,8 @@ const TwitterCommunity: React.FC<TwitterCommunityPros> = ({ Data }) => {
   );
   const getText =
     getFamCount !== undefined
-      ? Data.title_community.replace("#XXX", getFamCount)
-      : Data.title_community;
+      ? t.title_community.replace("#XXX", getFamCount)
+      : t.title_community;
   const handelClickedToCopyText = () => {
     if (navigator.clipboard) {
       navigator.clipboard
@@ -64,7 +65,7 @@ const TwitterCommunity: React.FC<TwitterCommunityPros> = ({ Data }) => {
           href="https://twitter.com/i/lists/1376636817089396750/members"
           rel="noopener noreferrer"
           role="link"
-          title={Data.title_community_hover}
+          title={t.title_community_hover}
           className="hover:underline hover:text-blue-spindle relative h-full"
         >
           {getText}
@@ -78,12 +79,12 @@ const TwitterCommunity: React.FC<TwitterCommunityPros> = ({ Data }) => {
           isCopied ? "span-bat-sound-copied" : "span-bat-sound"
         }`}
         dangerouslySetInnerHTML={{
-          __html: twemoji.parse(Data.description_community),
+          __html: twemoji.parse(t.description_community),
         }}
         onClick={handelClickedToCopyText}
         onMouseEnter={handleMouseEnter}
       />
-      <TwitterProfile Data={Data} profileList={data && data.profiles} />
+      <TwitterProfile profileList={data && data.profiles} />
     </>
   );
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,12 @@
 import { AppProps } from "next/app";
+import { TranslationProvider } from "../utils/use-translation";
+import Data from "../../locales/en/data.json";
 import "../../styles/index.scss";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <TranslationProvider value={Data}>
+      <Component {...pageProps} />
+    </TranslationProvider>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,25 +1,26 @@
 import * as React from "react";
 import { NextPage } from "next";
 import Head from "next/head";
-import Data from "../../locales/en/data.json";
 import ComingSoon from "../components/ComingSoon";
+import { useTranslations } from "../utils/use-translation";
 
 type IndexPageProps = {};
 const IndexPage: NextPage<IndexPageProps> = () => {
+  const { translations: t } = useTranslations();
   return (
     <>
       <Head>
-        <title>{Data.title}</title>
+        <title>{t.title}</title>
         <meta httpEquiv="cache-control" content="max-age=0" />
         <meta httpEquiv="cache-control" content="no-cache" />
         <meta httpEquiv="expires" content="0" />
         <meta httpEquiv="pragma" content="no-cache" />
-        <meta name="description" content={Data.title} />
-        <meta name="keywords" content={Data.meta_keywords} />
-        <meta property="og:title" content={Data.title} />
-        <meta property="og:description" content={Data.meta_description} />
-        <meta property="og:image" content={Data.og_img} />
-        <meta property="og:url" content={Data.og_url} />
+        <meta name="description" content={t.title} />
+        <meta name="keywords" content={t.meta_keywords} />
+        <meta property="og:title" content={t.title} />
+        <meta property="og:description" content={t.meta_description} />
+        <meta property="og:image" content={t.og_img} />
+        <meta property="og:url" content={t.og_url} />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:creator" content="@ultrasoundmoney" />
         <link rel="icon" href="/favicon.png" />
@@ -27,7 +28,7 @@ const IndexPage: NextPage<IndexPageProps> = () => {
         <link rel="apple-touch-icon" href="/favicon.png"></link>
         <meta name="theme-color" content="#131827" />
       </Head>
-      <ComingSoon Data={Data} />
+      <ComingSoon />
     </>
   );
 };

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -1,26 +1,27 @@
 import * as React from "react";
 import { NextPage } from "next";
 import Head from "next/head";
-import Data from "../../locales/en/data.json";
 import LandingPage from "../components/Landing";
+import { useTranslations } from "../utils/use-translation";
 
 type IndexPageProps = {};
 const IndexPage: NextPage<IndexPageProps> = () => {
+  const { translations: t } = useTranslations();
   return (
     <>
       <Head>
-        <title>{Data.title}</title>
+        <title>{t.title}</title>
         <link rel="icon" href="/favicon.png" />
-        <meta name="description" content={Data.title} />
-        <meta name="keywords" content={Data.meta_keywords} />
-        <meta property="og:title" content={Data.title} />
-        <meta property="og:description" content={Data.meta_description} />
-        <meta property="og:image" content={Data.og_img} />
-        <meta property="og:url" content={Data.og_url} />
+        <meta name="description" content={t.title} />
+        <meta name="keywords" content={t.meta_keywords} />
+        <meta property="og:title" content={t.title} />
+        <meta property="og:description" content={t.meta_description} />
+        <meta property="og:image" content={t.og_img} />
+        <meta property="og:url" content={t.og_url} />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:creator" content="@ultrasoundmoney" />
       </Head>
-      <LandingPage Data={Data} />
+      <LandingPage />
     </>
   );
 };

--- a/src/utils/use-translation.tsx
+++ b/src/utils/use-translation.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+const TranslationContext = React.createContext<Data>({});
+
+export const TranslationProvider: React.FC<{
+  value?: Data;
+  children: React.ReactNode;
+}> = ({ value, children }) => {
+  return (
+    <TranslationContext.Provider value={value}>
+      {children}
+    </TranslationContext.Provider>
+  );
+};
+
+export function useTranslations(): { translations: Data } {
+  const translations = React.useContext(TranslationContext);
+  return {
+    translations: translations,
+  };
+}


### PR DESCRIPTION
Using context for things like this is likely preferable to passing `Data` around through the whole react tree. This way, only components that require translations need to be concerned with it. Thoughts?

Note: The base branch here is `dev-merge` while we figure out what to do on `#59`. After we figure out what to do there, I'll update the base branch here to `dev`.