### PR TITLE
WIP: refine nft section

### DIFF
--- a/src/components/NftDrop/index.tsx
+++ b/src/components/NftDrop/index.tsx
@@ -7,16 +7,16 @@ const NftDrop: React.FC = () => {
   const { translations: t } = useTranslations();
   const refVideo = React.useRef(null);
 
+  // React does not set the muted attribute causing video to not autoplay as
+  // most browsers block autoplaying video. We set the attribute manually.
+  // https://github.com/facebook/react/issues/10389
   React.useEffect(() => {
     if (!refVideo.current) {
       return;
     }
 
-    //open bug since 2017 that you cannot set muted in video element https://github.com/facebook/react/issues/10389
     refVideo.current.defaultMuted = true;
     refVideo.current.muted = true;
-
-    refVideo.current.srcObject = "/nft-drop.mp4";
   });
 
   return (


### PR DESCRIPTION
Currently, sm, md, lg, xl sizes look like:

![](https://user-images.githubusercontent.com/2011351/125479038-d70d8248-994f-4370-89a9-132c3217aaba.png)

![](https://user-images.githubusercontent.com/2011351/125479059-1858f5c2-be43-4de2-bf77-22599bb737db.png)

![](https://user-images.githubusercontent.com/2011351/125480384-e8321195-64ce-45f0-8f34-69d56294e1cd.png)

![](https://user-images.githubusercontent.com/2011351/125480299-7be4b8fe-c5c2-48ce-885e-a624abe04038.png)

![](https://user-images.githubusercontent.com/2011351/125480337-f8855acb-ea07-4845-a03c-2cb35f964f1a.png)

For xl I'll restrict width, for md I'll just fix the obvious, for sm I could use some suggestions. @tomasssola what do you think we should do on mobile?