### PR TITLE
fix: prevent supply chart from getting clipped

### DIFF
--- a/src/components/SupplyView/index.tsx
+++ b/src/components/SupplyView/index.tsx
@@ -74,11 +74,8 @@ const SupplyView: React.FC<{}> = () => {
     setShowBreakdown(false);
   }, []);
 
-  const handleOnPeakProjected = React.useCallback(() => {
-    setIsPeakPresent(true);
-  }, []);
-  const handleOnNoPeakProjected = React.useCallback(() => {
-    setIsPeakPresent(false);
+  const handleOnPeakProjectedToggle = React.useCallback((isPeakPresent) => {
+    setIsPeakPresent(isPeakPresent);
   }, []);
 
   const daysUntilProjectedMerge = projectedMergeDate.diff(
@@ -114,8 +111,7 @@ const SupplyView: React.FC<{}> = () => {
         projectedBaseGasPrice={projectedBaseGasPrice}
         projectedMergeDate={projectedMergeDate}
         showBreakdown={showBreakdown}
-        onPeakProjected={handleOnPeakProjected}
-        onNoPeakProjected={handleOnNoPeakProjected}
+        onPeakProjectedToggle={handleOnPeakProjectedToggle}
       />
 
       <div className={styles.params}>


### PR DESCRIPTION
Sometimes the chart can render cut off:

![image](https://user-images.githubusercontent.com/875591/126729079-ca548334-520f-4e82-9455-0a91282ef754.png)

Still not sure exactly why this is happening – seems like the container we render the chart into starts out large and then resizes to be smaller immediately upon page load, possibly due to some CSS being applied lately.

This PR fixes the issue by forcing a chart re-render if necessary.