### PR TITLE
[Card-64], Should remove delay on hover effect on landing page

### DIFF
--- a/src/components/Landing/BlockBtcEthUsd/CurrencyTabs.tsx
+++ b/src/components/Landing/BlockBtcEthUsd/CurrencyTabs.tsx
@@ -13,7 +13,7 @@ const CurrencyTabs: React.FC<CurrencyTabsProps> = ({
         onClick={() => {
           setSpecificTab("btc");
         }}
-        className={`pl-10 pr-6 cursor-pointer py-3 text-sm text-white rounded-lg font-roboto leading-none span--btc transition-all delay-200 duration-100 mx-2 ${
+        className={`pl-10 pr-6 cursor-pointer py-3 text-sm text-white rounded-lg font-roboto leading-none span--btc transition-all duration-100 mx-2 ${
           cryptoType === "btc"
             ? "bg-blue-tangaroa hover:bg-blue-tangaroa focus:bg-blue-tangaroa"
             : "bg-transparent hover:bg-blue-tangaroa focus:bg-blue-tangaroa"
@@ -25,7 +25,7 @@ const CurrencyTabs: React.FC<CurrencyTabsProps> = ({
         onClick={() => {
           setSpecificTab("eth");
         }}
-        className={`pl-10 pr-6 cursor-pointer py-3 text-sm text-white rounded-lg font-roboto leading-none span--eth transition-all delay-200 duration-100 mx-2 ${
+        className={`pl-10 pr-6 cursor-pointer py-3 text-sm text-white rounded-lg font-roboto leading-none span--eth transition-all duration-100 mx-2 ${
           cryptoType === "eth"
             ? "bg-blue-tangaroa hover:bg-blue-tangaroa focus:bg-blue-tangaroa"
             : "bg-transparent hover:bg-blue-tangaroa focus:bg-blue-tangaroa"
@@ -37,7 +37,7 @@ const CurrencyTabs: React.FC<CurrencyTabsProps> = ({
         onClick={() => {
           setSpecificTab("usd");
         }}
-        className={`pl-10 pr-6 cursor-pointer py-3 text-sm text-white rounded-lg font-roboto leading-none span--usd transition-all delay-200 duration-100 mx-2 ${
+        className={`pl-10 pr-6 cursor-pointer py-3 text-sm text-white rounded-lg font-roboto leading-none span--usd transition-all duration-100 mx-2 ${
           cryptoType === "usd"
             ? "bg-blue-tangaroa hover:bg-blue-tangaroa focus:bg-blue-tangaroa"
             : "bg-transparent hover:bg-blue-tangaroa focus:bg-blue-tangaroa"


### PR DESCRIPTION
*Removed Bootstrap class 'delay-200' to remove delay on hover on buttons in the bottom graphs block, which are under the graphs
    
Trello task card 64: https://trello.com/c/2J0hFbZx/64-currency-graph-button-effects