### PR TITLE
[card-56], it should make correct scrolling

### DIFF
--- a/src/components/Navigation/Steps.tsx
+++ b/src/components/Navigation/Steps.tsx
@@ -73,7 +73,9 @@ const Steps = React.forwardRef<HTMLDivElement | null, StepsProps>(
         setPositinLogo(e.pageX);
       };
       const handleUpLogo = () => {
-        onActionLogo("up");
+        if (activeLogo !== "move" && activeLogo !== "none") {
+          onActionLogo("up");
+        }
         if (!logoOnDots && ref.current?.style) {
           setTimeout(() => onActionLogo("none"), 800);
         }

--- a/src/components/Navigation/helpers.ts
+++ b/src/components/Navigation/helpers.ts
@@ -69,7 +69,6 @@ export const setScrollPosition = (
       controllPoints[distanceOrderItem - 1]?.offsetY +
       blockYOffset -
       drawingLineHight;
-
     window.scrollTo({ top: offsetValue });
     const isActiveDot =
       iconOffsetInBlock > (distanceWidth / 4) * 3 &&


### PR DESCRIPTION
*Set the condition to avoid setting scroll position twice and by the way it prevents jumping of the scroll, when you up the mouse button

Trello task card 56: https://trello.com/c/WVk6yabp/56-scroll-through-page-using-ethereum-logo-in-top-navbar