### PR TITLE
[fix/card-67], should change the scroll behavior of the BTC/ETH/USD graph

### DIFF
--- a/src/components/ContentBlock/ContentBlockMedia.tsx
+++ b/src/components/ContentBlock/ContentBlockMedia.tsx
@@ -12,7 +12,7 @@ const ContentBlockMedia: React.FC<ContentBlockMediaProps> = ({
   text,
 }) => {
   return (
-    <>
+    <div>
       {img !== null && img != undefined && (
         <img
           className="text-left mr-auto mb-6"
@@ -32,7 +32,7 @@ const ContentBlockMedia: React.FC<ContentBlockMediaProps> = ({
           __html: text,
         }}
       />
-    </>
+    </div>
   );
 };
 

--- a/src/components/Landing/BTCETH/BlockText.tsx
+++ b/src/components/Landing/BTCETH/BlockText.tsx
@@ -30,16 +30,20 @@ const BlockText: React.FC<{
     }
   }, [currentIndexElement]);
 
-  return (
-    <motion.div
-      className="graph_text_eth"
-      animate={activePosition}
-      transition={{ duration: 1 }}
-      variants={variants}
-    >
-      <ContentBlockMedia title={title} text={text} />
-    </motion.div>
-  );
+  if (window.innerWidth <= 740) {
+    return (
+      <motion.div
+        className="graph_text_eth"
+        animate={activePosition}
+        transition={{ duration: 1 }}
+        variants={variants}
+      >
+        <ContentBlockMedia title={title} text={text} />
+      </motion.div>
+    );
+  } else {
+    return <ContentBlockMedia title={title} text={text} />;
+  }
 };
 
 export default BlockText;

--- a/src/components/Landing/BlockBtcEthUsd/helpers.ts
+++ b/src/components/Landing/BlockBtcEthUsd/helpers.ts
@@ -1,0 +1,28 @@
+const GRAPH_TOP_VALUE = 400;
+const graphType = ["none", "btc", "eth", "usd"];
+
+export const handleGraphs = (
+  graphsBlockElem: HTMLElement,
+  graphTextElem: HTMLElement,
+  setCryptoType: (val: string) => void
+) => {
+  const textBlockToBottom = graphTextElem.getBoundingClientRect().bottom;
+  const textBlockToHeight = graphTextElem.getBoundingClientRect().height;
+  const bottomHeight = textBlockToHeight + GRAPH_TOP_VALUE;
+  const heightCoeffValue = (textBlockToBottom - bottomHeight) / 2;
+  if (
+    textBlockToBottom > heightCoeffValue &&
+    graphsBlockElem.style.position !== "sticky"
+  ) {
+    graphsBlockElem.style.position = "sticky";
+    graphsBlockElem.style.top = GRAPH_TOP_VALUE + "px";
+  }
+  const textBlocksArray = Array.from(graphTextElem.children);
+  for (let i = 0; i <= textBlocksArray.length - 1; i++) {
+    const topValue = textBlocksArray[i].getBoundingClientRect().top;
+    if (topValue >= GRAPH_TOP_VALUE) {
+      setCryptoType(graphType[i]);
+      break;
+    }
+  }
+};

--- a/src/components/Landing/BlockBtcEthUsd/index.tsx
+++ b/src/components/Landing/BlockBtcEthUsd/index.tsx
@@ -8,6 +8,7 @@ import BtcSvg from "./BtcSvg";
 import UsdSvg from "./UsdSvg";
 import NoneSvg from "./NoneSvg";
 import CurrencyTabs from "./CurrencyTabs";
+import { handleGraphs } from "./helpers";
 
 interface Obj {
   [key: string]: any;
@@ -17,6 +18,8 @@ const TheUltraSound: FC<{}> = () => {
   const t = useContext(TranslationsContext);
   const pointRef = useRef(null);
   const graphRef = useRef<HTMLDivElement | null>(null);
+  const graphsBlockRef = useRef<HTMLDivElement | null>(null);
+  const graphTextRef = useRef<HTMLDivElement | null>(null);
   const [cryptoType, setCryptoType] = useState<string>("none");
   const tabs = ["none", "btc", "eth", "usd"];
   let timeoutId: null | ReturnType<typeof setTimeout> = null;
@@ -58,20 +61,26 @@ const TheUltraSound: FC<{}> = () => {
   };
 
   const onScroll = (event: Obj, important?: boolean) => {
-    eventScroll.current = event;
-    if (graphRef?.current) {
-      const rect = graphRef.current.getBoundingClientRect();
-      const trigger = window.scrollY + window.innerHeight / 2 - rect.height / 2;
-      elPosition.current = window.scrollY + rect.top;
-      const scrollTriggerStart =
-        elPosition.current < trigger + 50 && elPosition.current > trigger - 100;
-      if (scrollTriggerStart || important) {
-        document.body.style.overflowY = "hidden";
-        window.addEventListener("wheel", changeCryptoType);
-      } else {
-        document.body.style.overflowY = "scroll";
-        window.removeEventListener("wheel", changeCryptoType);
+    if (window.innerWidth <= 740) {
+      eventScroll.current = event;
+      if (graphRef?.current) {
+        const rect = graphRef.current.getBoundingClientRect();
+        const trigger =
+          window.scrollY + window.innerHeight / 2 - rect.height / 2;
+        elPosition.current = window.scrollY + rect.top;
+        const scrollTriggerStart =
+          elPosition.current < trigger + 50 &&
+          elPosition.current > trigger - 100;
+        if (scrollTriggerStart || important) {
+          document.body.style.overflowY = "hidden";
+          window.addEventListener("wheel", changeCryptoType);
+        } else {
+          document.body.style.overflowY = "scroll";
+          window.removeEventListener("wheel", changeCryptoType);
+        }
       }
+    } else if (graphsBlockRef.current && graphTextRef.current) {
+      handleGraphs(graphsBlockRef.current, graphTextRef.current, setCryptoType);
     }
   };
 
@@ -93,6 +102,32 @@ const TheUltraSound: FC<{}> = () => {
       graphRef?.current?.scrollIntoView({ block: "center" });
     }
   };
+
+  const setTextBlicksHeights = () => {
+    const graphBlockHeight = graphsBlockRef.current?.getBoundingClientRect()
+      .height;
+    if (graphTextRef.current) {
+      const blocks = graphTextRef.current.children;
+      if (window.innerWidth <= 740) {
+        for (let i = 0; i <= blocks.length - 1; i++) {
+          const el: any = blocks[i];
+          delete el.style.minHeight;
+        }
+      } else {
+        for (let i = 0; i <= blocks.length - 1; i++) {
+          const el: any = blocks[i];
+          el.style.minHeight = graphBlockHeight + "px";
+        }
+      }
+    }
+  };
+  useEffect(() => {
+    setTextBlicksHeights();
+    window.addEventListener("resize", setTextBlicksHeights);
+    return () => {
+      window.removeEventListener("resize", setTextBlicksHeights);
+    };
+  }, []);
 
   return (
     <>
@@ -130,18 +165,23 @@ const TheUltraSound: FC<{}> = () => {
           ref={graphRef}
           className="w-full md:w-9/12 flex flex-wrap justify-center ml-auto mr-auto"
         >
-          <div className="graph_text_containter w-full md:w-7/12 self-center order-2 md:order-1 md:px-20">
+          <div
+            ref={graphTextRef}
+            className="graph_text_containter w-full md:w-7/12 self-center order-2 md:order-1 md:px-20"
+          >
             <SVGrenderText typ={cryptoType} />
           </div>
           <div className="relative w-full md:w-5/12 order-1 md:order-1 mb-6 md:mb-0">
-            <CurrencyTabs
-              setSpecificTab={setSpecificTab}
-              cryptoType={cryptoType}
-            />
-            {cryptoType === "eth" && <EthSvg />}
-            {cryptoType === "btc" && <BtcSvg />}
-            {cryptoType === "usd" && <UsdSvg />}
-            {cryptoType === "none" && <NoneSvg />}
+            <div ref={graphsBlockRef}>
+              <CurrencyTabs
+                setSpecificTab={setSpecificTab}
+                cryptoType={cryptoType}
+              />
+              {cryptoType === "eth" && <EthSvg />}
+              {cryptoType === "btc" && <BtcSvg />}
+              {cryptoType === "usd" && <UsdSvg />}
+              {cryptoType === "none" && <NoneSvg />}
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
*Made graphs scrolling as it was in the example, whe our graph stops in some place, until we scroll all text information along the scroll
*Made dynamic updating the graphs when respective text next to graph

Trello card 67: https://trello.com/c/kOdZpeV2/67-change-the-scroll-behavior-of-the-btc-eth-usd-graph