### PR TITLE
[fix/card-67-1], should decrease the distance from top to graph block

### DIFF
--- a/src/components/Landing/BlockBtcEthUsd/helpers.ts
+++ b/src/components/Landing/BlockBtcEthUsd/helpers.ts
@@ -1,4 +1,4 @@
-const GRAPH_TOP_VALUE = 400;
+const GRAPH_TOP_VALUE = 250;
 const graphType = ["none", "btc", "eth", "usd"];
 
 export const handleGraphs = (
@@ -6,8 +6,9 @@ export const handleGraphs = (
   graphTextElem: HTMLElement,
   setCryptoType: (val: string) => void
 ) => {
-  const textBlockToBottom = graphTextElem.getBoundingClientRect().bottom;
-  const textBlockToHeight = graphTextElem.getBoundingClientRect().height;
+  const graphTextElemData = graphTextElem.getBoundingClientRect();
+  const textBlockToBottom = graphTextElemData.bottom;
+  const textBlockToHeight = graphTextElemData.height;
   const bottomHeight = textBlockToHeight + GRAPH_TOP_VALUE;
   const heightCoeffValue = (textBlockToBottom - bottomHeight) / 2;
   if (


### PR DESCRIPTION
*Decreased the distance from top to BTC/ETH/USD graph block on the landing page

Trello task 67: https://trello.com/c/kOdZpeV2/67-change-the-scroll-behavior-of-the-btc-eth-usd-graph