### PR TITLE
[fix/card-70], should change hrizontal scroll on mobile view

### DIFF
--- a/src/components/Navigation/Navigation.module.scss
+++ b/src/components/Navigation/Navigation.module.scss
@@ -31,3 +31,10 @@
     text-align: center;
   }
 }
+
+.mobileNavBarNav {
+  width: 100%;
+  @media (max-width: 500px) {
+    width: 200%;
+  }
+}

--- a/src/components/Navigation/Stepper.tsx
+++ b/src/components/Navigation/Stepper.tsx
@@ -9,7 +9,13 @@ import arrowRight from "../../assets/arrowRight.svg";
 import Steps from "./Steps";
 import { StepperContext } from "../../context/StepperContext";
 import { ActionLogo } from "./types";
-import { getIconOffset, showHideNavBar, setScrollPosition } from "./helpers";
+import {
+  getIconOffset,
+  showHideNavBar,
+  setScrollPosition,
+  setNavBarPosition,
+  MOBILE_VERTICAL_SCROLL_BREAK_POINT,
+} from "./helpers";
 import classes from "./Navigation.module.scss";
 
 const Stepper: React.FC = () => {
@@ -19,7 +25,6 @@ const Stepper: React.FC = () => {
   const [currentActionLogo, setCurrentActionLogo] = useState<ActionLogo>(
     "none"
   );
-  const [memoizedValue, setMemoizedValue] = useState<number>(0);
   const [pageLoad, setPageLoad] = useState(false);
   const handlerActionLogo = (value: ActionLogo) => setCurrentActionLogo(value);
   const controlPoints: any[] = Object.keys(
@@ -29,19 +34,28 @@ const Stepper: React.FC = () => {
   });
 
   const onScroll = useCallback(() => {
-    showHideNavBar(controlPoints, stepsRef.current!);
-    if (
-      currentActionLogo !== "up" &&
-      currentActionLogo !== "move" &&
-      currentActionLogo !== "down" &&
-      stepsRef.current &&
-      steperIconRef.current
-    ) {
-      const logoOffset = getIconOffset(controlPoints, pageLoad);
-      steperIconRef.current.style.left = `${logoOffset}%`;
-      setMemoizedValue(logoOffset);
+    const horizontalNavBar = stepsRef.current!;
+    const stepperIconElem = steperIconRef.current!;
+    showHideNavBar(controlPoints, horizontalNavBar);
+    if (window.innerWidth <= MOBILE_VERTICAL_SCROLL_BREAK_POINT) {
+      setNavBarPosition(
+        horizontalNavBar,
+        stepperIconElem,
+        controlPoints,
+        pageLoad
+      );
+    } else {
+      if (
+        currentActionLogo !== "up" &&
+        currentActionLogo !== "move" &&
+        currentActionLogo !== "down"
+      ) {
+        const logoOffset = getIconOffset(controlPoints, pageLoad);
+        stepperIconElem.style.left = `${logoOffset}%`;
+        horizontalNavBar.style.left = "0";
+      }
     }
-  }, [currentActionLogo, controlPoints]);
+  }, [currentActionLogo, controlPoints, pageLoad]);
   const [isLastTrackingElem, setIsLastTrackingElem] = useState<boolean>(false);
   const isDragging = useRef<boolean>(false);
   const setScrollPosOnLogoMove = (trackWidth: number, logoOffset: number) => {
@@ -71,13 +85,12 @@ const Stepper: React.FC = () => {
   return (
     <nav
       ref={stepsRef}
-      className="stepper_nav sticky top-0 left-0 w-full flex justify-between md:justify-start p-3 bg-blue-tangaroa z-50"
+      className={`${classes.mobileNavBarNav} stepper_nav sticky top-0 left-0 w-full flex justify-between md:justify-start p-3 bg-blue-tangaroa z-50`}
     >
       <div className="w-full px-1 md:px-4 mx-auto flex flex-wrap items-center justify-between">
         <Steps
           onActionLogo={handlerActionLogo}
           activeLogo={currentActionLogo}
-          currentPositionLogo={memoizedValue}
           ref={steperIconRef}
           controlPoints={controlPoints}
           setScroll={setScrollPosOnLogoMove}

--- a/src/components/Navigation/Steps.tsx
+++ b/src/components/Navigation/Steps.tsx
@@ -5,17 +5,11 @@ import StepperPoint from "./StepperPoint";
 import StepperTrack from "./StepperTrack";
 import { motion } from "framer-motion";
 import { StepsProps, ControlPointMutated } from "./types";
+import { MOBILE_VERTICAL_SCROLL_BREAK_POINT } from "./helpers";
 
 const Steps = React.forwardRef<HTMLDivElement | null, StepsProps>(
   (
-    {
-      controlPoints,
-      currentPositionLogo,
-      onActionLogo,
-      activeLogo,
-      setScroll,
-      isLastTrackingElem,
-    },
+    { controlPoints, onActionLogo, activeLogo, setScroll, isLastTrackingElem },
     ref
   ) => {
     const [activeBalls, setActiveBalls] = useState<ControlPointMutated[]>();
@@ -64,7 +58,8 @@ const Steps = React.forwardRef<HTMLDivElement | null, StepsProps>(
           ref.current?.style &&
           typeof cord === "object" &&
           e.pageX > cord.left &&
-          e.pageX < cord.right
+          e.pageX < cord.right &&
+          window.innerWidth > MOBILE_VERTICAL_SCROLL_BREAK_POINT
         ) {
           ref.current.style.left = `${e.pageX - marginLeft}px`;
           setScroll(cord.width, e.pageX - marginLeft);
@@ -76,7 +71,9 @@ const Steps = React.forwardRef<HTMLDivElement | null, StepsProps>(
         if (activeLogo !== "move" && activeLogo !== "none") {
           onActionLogo("up");
         } else {
-          onActionLogo("none");
+          setTimeout(() => {
+            onActionLogo("none");
+          }, 500);
         }
         window.removeEventListener("pointermove", handleMoveLogo);
         window.removeEventListener("pointerup", handleUpLogo);
@@ -93,14 +90,7 @@ const Steps = React.forwardRef<HTMLDivElement | null, StepsProps>(
           ref.current.removeEventListener("pointerdown", handleDownLogo);
         }
       };
-    }, [
-      ref,
-      trackWrapper,
-      currentPositionLogo,
-      logoOnDots,
-      onActionLogo,
-      setScroll,
-    ]);
+    }, [ref, trackWrapper, logoOnDots, onActionLogo, setScroll, activeLogo]);
 
     return (
       <div className="w-full h-full md:w-9/12 relative flex justify-around lg:justify-around items-center pt-5">

--- a/src/components/Navigation/helpers.ts
+++ b/src/components/Navigation/helpers.ts
@@ -113,3 +113,15 @@ export const showHideNavBar = (
       : stepsRefElem.classList.remove("active");
   }
 };
+
+export const MOBILE_VERTICAL_SCROLL_BREAK_POINT = 500;
+export const setNavBarPosition = (
+  horizontalNavBar: HTMLElement,
+  stepperIconElem: HTMLElement,
+  controlPoints: any[],
+  pageLoad: boolean
+): void => {
+  const logoOffset = getIconOffset(controlPoints, pageLoad);
+  horizontalNavBar.style.left = `-${logoOffset}%`;
+  stepperIconElem.style.left = `${logoOffset}%`;
+};

--- a/src/components/Navigation/types.ts
+++ b/src/components/Navigation/types.ts
@@ -13,7 +13,6 @@ export type ControlPointMutated = {
 
 export type StepsProps = {
   controlPoints: (ControlPoint | undefined)[];
-  currentPositionLogo: number;
   onActionLogo: (vodue: ActionLogo) => void;
   activeLogo: ActionLogo;
   setScroll: (trackWidth: number, logoOffset: number) => void;


### PR DESCRIPTION
*Made updated horizontal scroll
*Small refactoring - removed extra code
*Tirned of the function to move horizontal scroll icon manually
*Fixed issue with horizonal icon jump, that happens sometimes, when scrolling the horizontal scroll and the event 'mouseup'

Trello task 70: https://trello.com/c/EE38a2bY/70-page-navigation-on-mobile