### PR TITLE
Center graph, change triggers

### DIFF
--- a/src/components/Landing/BTCETH/BlockText.tsx
+++ b/src/components/Landing/BTCETH/BlockText.tsx
@@ -28,7 +28,7 @@ const BlockText: React.FC<BlockTextProps> = ({ title, text }) => {
 
   return (
     <div
-      className="flex flex-col justify-center mb-20"
+      className="flex flex-col justify-center lg:mb-20 pt-20 lg:pt-0"
       style={{ transition: "0.2s" }}
       ref={text_block}
     >

--- a/src/components/Landing/BlockBtcEthUsd/BlockBtcEthUsd.module.scss
+++ b/src/components/Landing/BlockBtcEthUsd/BlockBtcEthUsd.module.scss
@@ -74,7 +74,6 @@
 }
 .graphsBlock {
   position: sticky;
-  top: 200px;
   height: fit-content;
   background-color: rgba(20, 26, 47, var(--tw-bg-opacity));
 }
@@ -86,10 +85,10 @@
   justify-content: center;
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1024px) {
   .graphsBlock {
-    top: 60px;
-    padding-top: 30px;
+    top: 0 !important;
+    padding-top: 150px;
   }
   .graphsBlock::before {
     content: "";

--- a/src/components/Landing/BlockBtcEthUsd/helpers.ts
+++ b/src/components/Landing/BlockBtcEthUsd/helpers.ts
@@ -1,18 +1,27 @@
 export type graphTypes = "none" | "btc" | "eth" | "usd";
-export const WINDOW_BREAK_POINT = 740;
+export const WINDOW_BREAK_POINT = 1024;
 const graphType = ["none", "btc", "usd", "eth"];
 
 export const handleGraphs = (
-  topBreakPointValue: number,
+  graphsBlock: HTMLDivElement | null,
   arrayBlocksText: Element[],
-  offset: number,
   setCryptoType: (val: string) => void,
 ) => {
-  for (let i = 0; i <= arrayBlocksText.length - 1; i++) {
-    const topValue = arrayBlocksText[i].getBoundingClientRect().top + offset;
-    if (topValue >= topBreakPointValue) {
-      setCryptoType(graphType[i]);
-      break;
+  if (graphsBlock) {
+    for (let i = arrayBlocksText.length; i--; ) {
+      //take value top of title
+      const block = arrayBlocksText[i];
+      const bottomBlock = block.getBoundingClientRect().bottom;
+
+      const trigger =
+        window.innerWidth > WINDOW_BREAK_POINT
+          ? bottomBlock - block.clientHeight / 2
+          : bottomBlock - block.clientHeight;
+      const bottomGraphsBlock = graphsBlock.getBoundingClientRect().bottom;
+      if (trigger < bottomGraphsBlock) {
+        setCryptoType(graphType[i]);
+        break;
+      }
     }
   }
 };

--- a/src/components/Landing/BlockBtcEthUsd/index.tsx
+++ b/src/components/Landing/BlockBtcEthUsd/index.tsx
@@ -6,10 +6,9 @@ import SVGrenderText from "../BTCETH/generateText";
 import DrawingLine from "../DrawingLine";
 import Graphics from "./Graphics";
 import CurrencyTabs from "./CurrencyTabs";
-import { handleGraphs, setScrollPos } from "./helpers";
+import { handleGraphs, setScrollPos, WINDOW_BREAK_POINT } from "./helpers";
 import classes from "./BlockBtcEthUsd.module.scss";
 import type { graphTypes } from "./helpers";
-import { WINDOW_BREAK_POINT } from "./helpers";
 import styles from "../Landing.module.scss";
 
 const TheUltraSound: FC = () => {
@@ -19,15 +18,20 @@ const TheUltraSound: FC = () => {
   const graphsBlockRef = useRef<HTMLDivElement | null>(null);
   const graphTextRef = useRef<HTMLDivElement | null>(null);
   const [cryptoType, setCryptoType] = useState<string>("none");
-  const GRAPH_TOP_VALUE = 200;
-  const GRAPH_TOP_MOBILE_VALUE = 100;
 
   const setTextBlicksHeights = () => {
+    //center the graph
+    if (graphsBlockRef.current) {
+      const topGraph =
+        window.innerHeight / 2 - graphsBlockRef.current.clientHeight / 2;
+      graphsBlockRef.current.style.top = `${topGraph}px`;
+    }
+
     const graphBlockHeight =
       graphsBlockRef.current?.getBoundingClientRect().height;
     if (graphTextRef.current) {
       const blocks = graphTextRef.current.children;
-      if (window.innerWidth <= 1000) {
+      if (window.innerWidth <= WINDOW_BREAK_POINT) {
         for (let i = 0; i <= blocks.length - 1; i++) {
           const el = blocks[i] as HTMLDivElement;
           el.style.minHeight = "auto";
@@ -43,21 +47,10 @@ const TheUltraSound: FC = () => {
 
   useEffect(() => {
     if (!graphsBlockRef.current || !graphTextRef.current) return;
-    const offset = window.innerWidth * 0.2;
-    const topBreakPointValue: number =
-      window.innerWidth <= WINDOW_BREAK_POINT
-        ? GRAPH_TOP_MOBILE_VALUE +
-          graphsBlockRef.current.getBoundingClientRect().height
-        : GRAPH_TOP_VALUE;
     const textBlocksArray = Array.from(graphTextRef.current.children);
     const onScroll = () => {
       if (graphTextRef.current) {
-        handleGraphs(
-          topBreakPointValue,
-          textBlocksArray,
-          offset,
-          setCryptoType,
-        );
+        handleGraphs(graphsBlockRef.current, textBlocksArray, setCryptoType);
       }
     };
     window.addEventListener("scroll", onScroll);


### PR DESCRIPTION
This is where I fix the problem with the currency graph

Problem: when you click the chart buttons ( btc, usd or eth) scrolling to text is not correct on large screens
Solution: I centered chart position for medium and large screens ( screenshot 1 ) and changed triggers of animation. Now for medium and large screens animation starts to work at the center of the text block ( screenshot 1, red line) and for mobile devices the animation starts to work at this distance ( screenshot 2 )

P.S I also corrected not beautiful text display at the top for mobile devices ( screenshot 3 )

![image](https://user-images.githubusercontent.com/93117534/189157461-048b5d66-9951-4759-9422-a4dd72984422.png)
![image](https://user-images.githubusercontent.com/93117534/189157549-73c6c833-4945-4c82-8633-5cf9366da8e3.png)
![image](https://user-images.githubusercontent.com/93117534/189157576-8cafc6a8-680c-4e18-bcf1-2514374d0204.png)
