### PR TITLE
fix: horizontal scrollbar added when confetti is active

### DIFF
--- a/src/components/Dashboard/index.tsx
+++ b/src/components/Dashboard/index.tsx
@@ -195,6 +195,7 @@ const Dashboard: FC = () => {
   const videoEl = useRef<HTMLVideoElement>(null);
   const { simulateDeflationary } = featureFlags;
   const { showConfetti } = useConfetti(simulateDeflationary);
+  const showVideo = isDeflationary || simulateDeflationary;
 
   const handleClickTimeFrame = useCallback(() => {
     setTimeFrame((timeFrame) => getNextTimeFrame(timeFrame));
@@ -213,7 +214,7 @@ const Dashboard: FC = () => {
   }, []);
 
   useEffect(() => {
-    if (!isDeflationary || typeof window === "undefined") {
+    if (!showVideo || typeof window === "undefined") {
       return;
     }
 
@@ -224,7 +225,7 @@ const Dashboard: FC = () => {
       videoEl.current.pause();
     }, 22000);
     return () => window.clearTimeout(id);
-  }, [isDeflationary]);
+  }, [showVideo]);
 
   return (
     <FeatureFlagsContext.Provider value={featureFlags}>
@@ -233,15 +234,15 @@ const Dashboard: FC = () => {
         highlightColor="#565b7f"
         enableAnimation={true}
       >
-        <canvas
-          className={`pointer-events-none absolute z-10 ${
-            showConfetti ? "" : "hidden"
-          }`}
-          id="confetti-canvas"
-        ></canvas>
         <GasPriceTitle />
         <HeaderGlow />
-        <div className="container mx-auto">
+        <div className="container mx-auto overflow-x-hidden relative">
+          <canvas
+            className={`pointer-events-none absolute z-10 ${
+              showConfetti ? "" : "hidden"
+            }`}
+            id="confetti-canvas"
+          ></canvas>
           <BasicErrorBoundary>
             <AdminTools setFlag={setFlag} />
           </BasicErrorBoundary>
@@ -250,21 +251,23 @@ const Dashboard: FC = () => {
               <TopBar />
             </BasicErrorBoundary>
           </div>
-          <video
-            ref={videoEl}
-            className={`
-              absolute left-0 right-0 top-10 -z-10 mx-auto
-              md:-top-10
-              ${isDeflationary || simulateDeflationary ? "" : "hidden"}
-            `}
-            autoPlay
-            loop
-            muted
-            playsInline
-          >
-            <source src="/bat-480.mov" type="video/mp4;codecs=hvc1" />
-            <source src="/bat-480.webm" type="video/webm" />
-          </video>
+          {showVideo &&
+            <video
+              ref={videoEl}
+              className={`
+                absolute left-0 right-0 top-10 -z-10 mx-auto
+                md:-top-10
+                ${isDeflationary || simulateDeflationary ? "" : "hidden"}
+              `}
+              autoPlay
+              loop
+              muted
+              playsInline
+            >
+              <source src="/bat-480.mov" type="video/mp4;codecs=hvc1" />
+              <source src="/bat-480.webm" type="video/webm" />
+            </video>
+          }
           <MainTitle onClick={handleToggleBatLoop}>ultra sound money</MainTitle>
           <SupplySection
             timeFrame={timeFrame}

--- a/src/components/Dashboard/index.tsx
+++ b/src/components/Dashboard/index.tsx
@@ -118,13 +118,6 @@ const GasPriceTitle = () => {
   );
 };
 
-const confettiSettings = {
-  target: "confetti-canvas",
-  max: 20,
-  height: 1400,
-  props: [{ type: "svg", src: "/bat-own.svg" }],
-};
-
 const useIsDeflationary = () => {
   const supplyOverTime = useSupplyOverTime();
   const supplySinceMerge = supplyOverTime?.since_merge;
@@ -168,6 +161,14 @@ const useConfetti = (simulateDeflationary: boolean): UseConfetti => {
     // If confetti hasn't ran and last supply is under merge supply, run
     setShowConfetti(true);
     setConfettiRan(true);
+
+    const confettiSettings = {
+      target: "confetti-canvas",
+      max: 20,
+      width: document.body.clientWidth,
+      height: 1400,
+      props: [{ type: "svg", src: "/bat-own.svg" }],
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const confetti = new ConfettiGenerator(confettiSettings) as {
@@ -236,13 +237,15 @@ const Dashboard: FC = () => {
       >
         <GasPriceTitle />
         <HeaderGlow />
-        <div className="container mx-auto overflow-x-hidden relative">
+        
+        <div className="confetti-container absolute bottom-0 top-0 left-0 right-0 overflow-hidden pointer-events-none z-10">
           <canvas
-            className={`pointer-events-none absolute z-10 ${
-              showConfetti ? "" : "hidden"
-            }`}
+            className={showConfetti ? "" : "hidden"}
             id="confetti-canvas"
           ></canvas>
+        </div>
+        
+        <div className="container mx-auto">
           <BasicErrorBoundary>
             <AdminTools setFlag={setFlag} />
           </BasicErrorBoundary>


### PR DESCRIPTION
While poking around ultrasound.money with the web dev tools I noticed there was an animation that loads into an invisible video element. Wondering what that was about I went to Github and found its trigger and the confetti. Awesome! 🦇 🔈 

This pull request has two fixes surrounding these components:
- The video element is now only added to the DOM once ETH goes net deflationary, making the video file only loaded when needed. Other curious developers will be less likely to stumble upon the surprise this way, and some bandwidth is saved until enough ETH has been burned :)
- There was a horizontal scrollbar appearing on the page when the confetti was active. I fixed this by setting its parent's overflow-x style to none. I had to move the canvas deeper into the DOM because it was right at the top of the Dashboard component, but it displays the same way as before.

Before:
![image](https://user-images.githubusercontent.com/89714213/198812644-e4469b69-4d3a-4a30-bcf6-e014bc954c20.png)

After:
![image](https://user-images.githubusercontent.com/89714213/198812942-c609a714-ab2b-4e65-9935-4a4bf2c55b87.png)
