### PR TITLE
fix for overlaying PE icons #249

### DIFF
--- a/src/api/pe-ratios.ts
+++ b/src/api/pe-ratios.ts
@@ -1,7 +1,7 @@
 import useSWR from "swr";
 import { fetchJsonSwr } from "./fetchers";
 
-type PeRatios = {
+export type PeRatios = {
   AAPL: number;
   AMZN: number;
   DIS: number;

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -170,6 +170,7 @@ const CompanyMarkers: FC<
       {shownList.map((marker: any) => {
         return (
           <Marker
+            key={marker.symbol}
             icon={marker.icon}
             peRatio={marker.peRatio}
             ratio={linearFromLog(marker.peRatio)}

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -84,6 +84,50 @@ const MarkerText: FC<{ children: ReactNode; ratio: number }> = ({
   </div>
 );
 
+
+const CompanyMarkers: FC<typeof usePeRatios & { ETH: number, peRatios: any }> = ({ peRatios }) => {
+  const markerList: Array<typeof Marker | undefined> =
+    peRatios !== undefined
+      ? [
+          { alt: "ethereum logo", icon: "eth", peRatio: peRatios.ETH, ratio: peRatios.ETH, symbol: "ETH"},
+          { alt: "apple logo", icon: "apple", peRatio: peRatios.AAPL, ratio: peRatios.AAPL, Symbol: "AAPL"},
+          { alt: "amazon logo", icon: "amazon", peRatio: peRatios.AMZN, ratio: peRatios.AMZN, Symbol: "AMZN"},
+          { alt: "intel logo", icon: "intel", peRatio: peRatios.INTC, ratio: peRatios.INTC, Symbol: "INTC"},
+          { alt: "google logo", icon: "google", peRatio: peRatios.GOOGL, ratio: peRatios.GOOGL, symbol: "GOOGL"},
+          { alt: "netflix logo", icon: "netflix", peRatio: peRatios.NFLX, ratio: peRatios.NFLX, symbol: "NFLX"},
+          { alt: "tesla logo", icon: "tesla", peRatio: peRatios.TSLA, ratio: peRatios.TSLA, symbol: "TSLA"},
+          { alt: "disney logo", icon: "disney", peRatio: peRatios.DIS, ratio: peRatios.DIS, symbol: "DIS"},
+        ]
+      : [];
+
+  const shownList = markerList
+    .reduce((list: Array<typeof Marker | undefined>, marker) => {
+      const someConflict = list.some((shownMarker) => Math.abs(shownMarker.peRatio - marker.peRatio) < 4);
+
+      if (someConflict) {
+        return list;
+      }
+
+      return [...list, marker];
+    }, [])
+    .sort((m1, m2) => m1.value - m2.value);
+
+  return (
+    <>
+      {shownList.map((marker: any) => {
+        return (
+          <Marker
+            icon={marker.icon} 
+            peRatio={marker.peRatio}
+            ratio={linearFromLog(marker.peRatio)}
+            symbol={marker.symbol}
+          />
+        );
+      })}
+    </>
+  );
+};
+
 const monetaryPremiumMin = 1;
 const monetaryPremiumMax = 20;
 const monetaryPremiumRange = monetaryPremiumMax - monetaryPremiumMin;
@@ -255,80 +299,9 @@ const PriceModel: FC = () => {
               value={peRatioPosition}
             />
             <div className="absolute top-3 w-full select-none">
-              {peRatios !== undefined && (
+              {peRatios !== undefined && ethPeRatio !== undefined && (
                 // Because the actual slider does not span the entire visual slider, overlaying an element and setting the left is not perfect. We manually adjust values to match the slider more precisely. To improve this look into off-the-shelf components that allow for styled markers.
-                <>
-                  {typeof peRatios.INTC === "number" && (
-                    <Marker
-                      alt="intel logo"
-                      icon="intel"
-                      peRatio={peRatios.INTC}
-                      ratio={linearFromLog(peRatios.INTC)}
-                      symbol="INTC"
-                    />
-                  )}
-                  {peRatios.GOOGL !== null &&
-                    ethPeRatio !== undefined &&
-                    Math.abs(ethPeRatio - peRatios.GOOGL) > 4 && (
-                      <Marker
-                        alt="google logo"
-                        icon="google"
-                        peRatio={peRatios.GOOGL}
-                        ratio={linearFromLog(peRatios.GOOGL)}
-                        symbol="GOOGL"
-                      />
-                    )}
-                  {peRatios.NFLX !== null &&
-                    ethPeRatio !== undefined &&
-                    Math.abs(ethPeRatio - peRatios.NFLX) > 4 && (
-                      <Marker
-                        alt="netflix logo"
-                        icon="netflix"
-                        peRatio={peRatios.NFLX}
-                        ratio={linearFromLog(peRatios.NFLX)}
-                        symbol="NFLX"
-                      />
-                    )}
-                  {ethPeRatio !== undefined && (
-                    <Marker
-                      alt="ethereum logo"
-                      icon="eth"
-                      peRatio={ethPeRatio}
-                      ratio={linearFromLog(ethPeRatio)}
-                    />
-                  )}
-                  {peRatios.AMZN !== null &&
-                    ethPeRatio !== undefined &&
-                    peRatios.AMZN - ethPeRatio > 4 && (
-                      <Marker
-                        alt="amazon logo"
-                        icon="amazon"
-                        peRatio={peRatios.AMZN}
-                        ratio={linearFromLog(peRatios.AMZN)}
-                        symbol="AMZN"
-                      />
-                    )}
-                  {peRatios.DIS !== null &&
-                    ethPeRatio !== undefined &&
-                    Math.abs(peRatios.DIS - ethPeRatio) > 4 && (
-                      <Marker
-                        alt="disney logo"
-                        icon="disney"
-                        peRatio={peRatios.DIS}
-                        ratio={linearFromLog(peRatios.DIS)}
-                        symbol="DIS"
-                      />
-                    )}
-                  {peRatios.TSLA !== null && (
-                    <Marker
-                      alt="tesla logo"
-                      icon="tesla"
-                      peRatio={peRatios.TSLA}
-                      ratio={linearFromLog(peRatios.TSLA)}
-                      symbol="TSLA"
-                    />
-                  )}
-                </>
+                <CompanyMarkers peRatios={{ ...peRatios, ETH: ethPeRatio }} />
               )}
             </div>
           </div>
@@ -415,3 +388,4 @@ price = profits * P/E ratio * monetary premium`}
 };
 
 export default PriceModel;
+

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -164,8 +164,7 @@ const CompanyMarkers: FC<
       }
 
       return [...list, marker];
-    }, [])
-    .sort((m1, m2) => m1.value - m2.value);
+    }, []);
 
   return (
     <>

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -17,7 +17,7 @@ import { WidgetBackground, WidgetTitle } from "./WidgetSubcomponents";
 type MarkerProps = {
   alt?: string;
   icon: string;
-  peRatio: number | undefined;
+  peRatio: number;
   ratio: number;
   symbol?: string;
 };

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -90,7 +90,7 @@ const MarkerText: FC<{ children: ReactNode; ratio: number }> = ({
 const CompanyMarkers: FC<{ peRatios: PeRatios & { ETH: number } }> = ({
   peRatios,
 }) => {
-  const markerList: Array<typeof Marker | undefined> =
+  const markerList: MarkerProps[] =
     peRatios !== undefined
       ? [
           {
@@ -152,24 +152,23 @@ const CompanyMarkers: FC<{ peRatios: PeRatios & { ETH: number } }> = ({
         ]
       : [];
 
-  const shownList = markerList
-    .reduce((list: Array<typeof Marker | undefined>, marker) => {
-      if (marker?.peRatio === null) return list;
+  const shownList = markerList.reduce((list: Array<MarkerProps>, marker) => {
+    if (marker?.peRatio === null) return list;
 
-      const someConflict = list.some(
-        (shownMarker) => Math.abs(shownMarker.peRatio - marker.peRatio) < 4,
-      );
+    const someConflict = list.some(
+      (shownMarker) => Math.abs(shownMarker.peRatio - marker.peRatio) < 4,
+    );
 
-      if (someConflict) {
-        return list;
-      }
+    if (someConflict) {
+      return list;
+    }
 
-      return [...list, marker];
-    }, []);
+    return [...list, marker];
+  }, []);
 
   return (
     <>
-      {shownList.map((marker: any) => {
+      {shownList.map((marker) => {
         return (
           <Marker
             key={marker.symbol}

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -5,6 +5,7 @@ import { useAverageEthPrice } from "../api/average-eth-price";
 import { useBurnRates } from "../api/burn-rates";
 import { useEthPriceStats } from "../api/eth-price-stats";
 import { useImpreciseEthSupply } from "../api/eth-supply";
+import type { PeRatios } from "../api/pe-ratios";
 import { usePeRatios } from "../api/pe-ratios";
 import * as Format from "../format";
 import * as StaticEtherData from "../static-ether-data";
@@ -86,9 +87,9 @@ const MarkerText: FC<{ children: ReactNode; ratio: number }> = ({
   </div>
 );
 
-const CompanyMarkers: FC<
-  typeof usePeRatios & { ETH: number; peRatios: any }
-> = ({ peRatios }) => {
+const CompanyMarkers: FC<{ peRatios: PeRatios & { ETH: number } }> = ({
+  peRatios,
+}) => {
   const markerList: Array<typeof Marker | undefined> =
     peRatios !== undefined
       ? [

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -92,11 +92,11 @@ const CompanyMarkers: FC<typeof usePeRatios & { ETH: number, peRatios: any }> = 
           { alt: "ethereum logo", icon: "eth", peRatio: peRatios.ETH, ratio: peRatios.ETH, symbol: "ETH"},
           { alt: "apple logo", icon: "apple", peRatio: peRatios.AAPL, ratio: peRatios.AAPL, Symbol: "AAPL"},
           { alt: "amazon logo", icon: "amazon", peRatio: peRatios.AMZN, ratio: peRatios.AMZN, Symbol: "AMZN"},
-          { alt: "intel logo", icon: "intel", peRatio: peRatios.INTC, ratio: peRatios.INTC, Symbol: "INTC"},
-          { alt: "google logo", icon: "google", peRatio: peRatios.GOOGL, ratio: peRatios.GOOGL, symbol: "GOOGL"},
-          { alt: "netflix logo", icon: "netflix", peRatio: peRatios.NFLX, ratio: peRatios.NFLX, symbol: "NFLX"},
           { alt: "tesla logo", icon: "tesla", peRatio: peRatios.TSLA, ratio: peRatios.TSLA, symbol: "TSLA"},
           { alt: "disney logo", icon: "disney", peRatio: peRatios.DIS, ratio: peRatios.DIS, symbol: "DIS"},
+          { alt: "google logo", icon: "google", peRatio: peRatios.GOOGL, ratio: peRatios.GOOGL, symbol: "GOOGL"},
+          { alt: "netflix logo", icon: "netflix", peRatio: peRatios.NFLX, ratio: peRatios.NFLX, symbol: "NFLX"},
+          { alt: "intel logo", icon: "intel", peRatio: peRatios.INTC, ratio: peRatios.INTC, Symbol: "INTC"},
         ]
       : [];
 

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -14,14 +14,16 @@ import { BaseText } from "./Texts";
 import BodyText from "./TextsNext/BodyText";
 import { WidgetBackground, WidgetTitle } from "./WidgetSubcomponents";
 
-// Markers are positioned absolutely, manipulating their 'left' relatively to the full width bar which should be positioned relatively as their parent. Marker width
-const Marker: FC<{
+type MarkerProps = {
   alt?: string;
   icon: string;
   peRatio: number | undefined;
   ratio: number;
   symbol?: string;
-}> = ({ alt, icon, peRatio, ratio, symbol }) => {
+};
+
+// Markers are positioned absolutely, manipulating their 'left' relatively to the full width bar which should be positioned relatively as their parent. Marker width
+const Marker: FC<MarkerProps> = ({ alt, icon, peRatio, ratio, symbol }) => {
   const [isHovering, setIsHovering] = useState(false);
 
   return (

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -102,14 +102,14 @@ const CompanyMarkers: FC<
             icon: "apple",
             peRatio: peRatios.AAPL,
             ratio: peRatios.AAPL,
-            Symbol: "AAPL",
+            symbol: "AAPL",
           },
           {
             alt: "amazon logo",
             icon: "amazon",
             peRatio: peRatios.AMZN,
             ratio: peRatios.AMZN,
-            Symbol: "AMZN",
+            symbol: "AMZN",
           },
           {
             alt: "tesla logo",
@@ -144,7 +144,7 @@ const CompanyMarkers: FC<
             icon: "intel",
             peRatio: peRatios.INTC,
             ratio: peRatios.INTC,
-            Symbol: "INTC",
+            symbol: "INTC",
           },
         ]
       : [];

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -90,67 +90,64 @@ const MarkerText: FC<{ children: ReactNode; ratio: number }> = ({
 const CompanyMarkers: FC<{ peRatios: PeRatios & { ETH: number } }> = ({
   peRatios,
 }) => {
-  const markerList: MarkerProps[] =
-    peRatios !== undefined
-      ? [
-          {
-            alt: "ethereum logo",
-            icon: "eth",
-            peRatio: peRatios.ETH,
-            ratio: peRatios.ETH,
-            symbol: "ETH",
-          },
-          {
-            alt: "apple logo",
-            icon: "apple",
-            peRatio: peRatios.AAPL,
-            ratio: peRatios.AAPL,
-            symbol: "AAPL",
-          },
-          {
-            alt: "amazon logo",
-            icon: "amazon",
-            peRatio: peRatios.AMZN,
-            ratio: peRatios.AMZN,
-            symbol: "AMZN",
-          },
-          {
-            alt: "tesla logo",
-            icon: "tesla",
-            peRatio: peRatios.TSLA,
-            ratio: peRatios.TSLA,
-            symbol: "TSLA",
-          },
-          {
-            alt: "disney logo",
-            icon: "disney",
-            peRatio: peRatios.DIS,
-            ratio: peRatios.DIS,
-            symbol: "DIS",
-          },
-          {
-            alt: "google logo",
-            icon: "google",
-            peRatio: peRatios.GOOGL,
-            ratio: peRatios.GOOGL,
-            symbol: "GOOGL",
-          },
-          {
-            alt: "netflix logo",
-            icon: "netflix",
-            peRatio: peRatios.NFLX,
-            ratio: peRatios.NFLX,
-            symbol: "NFLX",
-          },
-          {
-            alt: "intel logo",
-            icon: "intel",
-            peRatio: peRatios.INTC,
-            ratio: peRatios.INTC,
-            symbol: "INTC",
-          },
-        ]
-      : [];
+  const markerList: MarkerProps[] = [
+    {
+      alt: "ethereum logo",
+      icon: "eth",
+      peRatio: peRatios.ETH,
+      ratio: peRatios.ETH,
+      symbol: "ETH",
+    },
+    {
+      alt: "apple logo",
+      icon: "apple",
+      peRatio: peRatios.AAPL,
+      ratio: peRatios.AAPL,
+      symbol: "AAPL",
+    },
+    {
+      alt: "amazon logo",
+      icon: "amazon",
+      peRatio: peRatios.AMZN,
+      ratio: peRatios.AMZN,
+      symbol: "AMZN",
+    },
+    {
+      alt: "tesla logo",
+      icon: "tesla",
+      peRatio: peRatios.TSLA,
+      ratio: peRatios.TSLA,
+      symbol: "TSLA",
+    },
+    {
+      alt: "disney logo",
+      icon: "disney",
+      peRatio: peRatios.DIS,
+      ratio: peRatios.DIS,
+      symbol: "DIS",
+    },
+    {
+      alt: "google logo",
+      icon: "google",
+      peRatio: peRatios.GOOGL,
+      ratio: peRatios.GOOGL,
+      symbol: "GOOGL",
+    },
+    {
+      alt: "netflix logo",
+      icon: "netflix",
+      peRatio: peRatios.NFLX,
+      ratio: peRatios.NFLX,
+      symbol: "NFLX",
+    },
+    {
+      alt: "intel logo",
+      icon: "intel",
+      peRatio: peRatios.INTC,
+      ratio: peRatios.INTC,
+      symbol: "INTC",
+    },
+  ];
 
   const shownList = markerList.reduce((list: Array<MarkerProps>, marker) => {
     if (marker?.peRatio === null) return list;

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -84,19 +84,68 @@ const MarkerText: FC<{ children: ReactNode; ratio: number }> = ({
   </div>
 );
 
-
-const CompanyMarkers: FC<typeof usePeRatios & { ETH: number, peRatios: any }> = ({ peRatios }) => {
+const CompanyMarkers: FC<
+  typeof usePeRatios & { ETH: number; peRatios: any }
+> = ({ peRatios }) => {
   const markerList: Array<typeof Marker | undefined> =
     peRatios !== undefined
       ? [
-          { alt: "ethereum logo", icon: "eth", peRatio: peRatios.ETH, ratio: peRatios.ETH, symbol: "ETH"},
-          { alt: "apple logo", icon: "apple", peRatio: peRatios.AAPL, ratio: peRatios.AAPL, Symbol: "AAPL"},
-          { alt: "amazon logo", icon: "amazon", peRatio: peRatios.AMZN, ratio: peRatios.AMZN, Symbol: "AMZN"},
-          { alt: "tesla logo", icon: "tesla", peRatio: peRatios.TSLA, ratio: peRatios.TSLA, symbol: "TSLA"},
-          { alt: "disney logo", icon: "disney", peRatio: peRatios.DIS, ratio: peRatios.DIS, symbol: "DIS"},
-          { alt: "google logo", icon: "google", peRatio: peRatios.GOOGL, ratio: peRatios.GOOGL, symbol: "GOOGL"},
-          { alt: "netflix logo", icon: "netflix", peRatio: peRatios.NFLX, ratio: peRatios.NFLX, symbol: "NFLX"},
-          { alt: "intel logo", icon: "intel", peRatio: peRatios.INTC, ratio: peRatios.INTC, Symbol: "INTC"},
+          {
+            alt: "ethereum logo",
+            icon: "eth",
+            peRatio: peRatios.ETH,
+            ratio: peRatios.ETH,
+            symbol: "ETH",
+          },
+          {
+            alt: "apple logo",
+            icon: "apple",
+            peRatio: peRatios.AAPL,
+            ratio: peRatios.AAPL,
+            Symbol: "AAPL",
+          },
+          {
+            alt: "amazon logo",
+            icon: "amazon",
+            peRatio: peRatios.AMZN,
+            ratio: peRatios.AMZN,
+            Symbol: "AMZN",
+          },
+          {
+            alt: "tesla logo",
+            icon: "tesla",
+            peRatio: peRatios.TSLA,
+            ratio: peRatios.TSLA,
+            symbol: "TSLA",
+          },
+          {
+            alt: "disney logo",
+            icon: "disney",
+            peRatio: peRatios.DIS,
+            ratio: peRatios.DIS,
+            symbol: "DIS",
+          },
+          {
+            alt: "google logo",
+            icon: "google",
+            peRatio: peRatios.GOOGL,
+            ratio: peRatios.GOOGL,
+            symbol: "GOOGL",
+          },
+          {
+            alt: "netflix logo",
+            icon: "netflix",
+            peRatio: peRatios.NFLX,
+            ratio: peRatios.NFLX,
+            symbol: "NFLX",
+          },
+          {
+            alt: "intel logo",
+            icon: "intel",
+            peRatio: peRatios.INTC,
+            ratio: peRatios.INTC,
+            Symbol: "INTC",
+          },
         ]
       : [];
 
@@ -104,7 +153,9 @@ const CompanyMarkers: FC<typeof usePeRatios & { ETH: number, peRatios: any }> = 
     .reduce((list: Array<typeof Marker | undefined>, marker) => {
       if (marker?.peRatio === null) return list;
 
-      const someConflict = list.some((shownMarker) => Math.abs(shownMarker.peRatio - marker.peRatio) < 4);
+      const someConflict = list.some(
+        (shownMarker) => Math.abs(shownMarker.peRatio - marker.peRatio) < 4,
+      );
 
       if (someConflict) {
         return list;
@@ -119,7 +170,7 @@ const CompanyMarkers: FC<typeof usePeRatios & { ETH: number, peRatios: any }> = 
       {shownList.map((marker: any) => {
         return (
           <Marker
-            icon={marker.icon} 
+            icon={marker.icon}
             peRatio={marker.peRatio}
             ratio={linearFromLog(marker.peRatio)}
             symbol={marker.symbol}
@@ -390,4 +441,3 @@ price = profits * P/E ratio * monetary premium`}
 };
 
 export default PriceModel;
-

--- a/src/components/PriceModel.tsx
+++ b/src/components/PriceModel.tsx
@@ -102,6 +102,8 @@ const CompanyMarkers: FC<typeof usePeRatios & { ETH: number, peRatios: any }> = 
 
   const shownList = markerList
     .reduce((list: Array<typeof Marker | undefined>, marker) => {
+      if (marker?.peRatio === null) return list;
+
       const someConflict = list.some((shownMarker) => Math.abs(shownMarker.peRatio - marker.peRatio) < 4);
 
       if (someConflict) {


### PR DESCRIPTION
Here's a take on the PE marker rendering issue using with a setup like the 200y projection widget. I've set ETH on the top of the markerList and the others can be changed accordingly.