### PR TITLE
Integrate relay dashboard

### DIFF
--- a/src/components/BlueButton.tsx
+++ b/src/components/BlueButton.tsx
@@ -1,7 +1,11 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import BodyTextV2 from "./TextsNext/BodyTextV2";
 
-const BlueButton: FC = () => (
+type Props = {
+  children: ReactNode;
+};
+
+const BlueButton: FC<Props> = ({ children }) => (
   <button
     className={`
       group
@@ -17,7 +21,7 @@ const BlueButton: FC = () => (
       md:py-1.5
     `}
   >
-    <BodyTextV2 className="z-10">copy</BodyTextV2>
+    <BodyTextV2 className="z-10">{children}</BodyTextV2>
     <div
       className={`
         absolute left-[1px] right-[1px] top-[1px] bottom-[1px]

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as RelayConfig from "./relay/config";
+
+export const config = {
+  matcher: [
+    /*
+     * Match all paths except for:
+     * 1. /api routes
+     * 2. /_next (Next.js internals)
+     * 3. /fonts (inside /public)
+     * 4. /examples (inside /public)
+     * 5. all root files inside /public (e.g. /favicon.ico)
+     */
+    "/((?!api|_next|fonts|examples|[\\w-]+\\.\\w+).*)",
+  ],
+};
+
+export default function middleware(req: NextRequest) {
+  const url = req.nextUrl;
+
+  if (url.pathname === "/relay") {
+    const newUrl = RelayConfig.getDomain();
+    return NextResponse.redirect(newUrl);
+  }
+
+  const host = req.headers.get("host") || "";
+  if (host.startsWith("relay")) {
+    url.pathname = `/relay${url.pathname}`;
+    return NextResponse.rewrite(url);
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import * as RelayConfig from "./relay/config";
 
 export const config = {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,27 +15,11 @@ class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500&display=swap"
             rel="stylesheet"
           />
-          <meta name="description" content={SiteMetadata.description} />
-          <meta
-            name="keywords"
-            content="ultra sound money, ethereum, ETH, sound money, fee burn, EIP-1559"
-          />
-          {/* When sharing the site on twitter, twitter adds our metadata, this adds little value, so we remove it. To not spend a lot of time removing our metadata from every shared link we're disabling twitter metadata for now. */}
-          <meta property="og:title" content={SiteMetadata.title} />
-          <meta property="og:description" content={SiteMetadata.description} />
-          <meta property="og:image" content={SiteMetadata.image} />
-          <meta property="og:url" content="https://ultrasound.money" />
           <link rel="icon" href="/favicon.png" />
           <link rel="manifest" href="/manifest.json" />
           <link rel="apple-touch-icon" href="/favicon.png"></link>
           <meta name="theme-color" content="#131827" />
-          {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
-          <script
-            defer
-            data-domain="ultrasound.money"
-            data-api="https://ultrasound.money/cfw/event"
-            src="https://ultrasound.money/cfw/script.js"
-          />
+          <meta property="og:image" content={SiteMetadata.image} />
         </Head>
         <body className="bg-slateus-800 text-slateus-200 [&_.next-error-h1]:border-slateus-200">
           <Main />

--- a/src/pages/fampreview.tsx
+++ b/src/pages/fampreview.tsx
@@ -1,5 +1,6 @@
 import type { GetStaticProps, NextPage } from "next";
 import Head from "next/head";
+import Script from "next/script";
 import "react-loading-skeleton/dist/skeleton.css";
 import { SWRConfig } from "swr";
 import SiteMetadata from "../site-metadata";
@@ -74,14 +75,14 @@ const WrappedFamPage: NextPage<StaticProps> = ({ fallback }) => (
       <meta property="og:title" content={SiteMetadata.title} />
       <meta property="og:description" content={SiteMetadata.description} />
       <meta property="og:url" content="https://ultrasound.money" />
-      {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
-      <script
-        defer
-        data-domain="ultrasound.money"
-        data-api="https://ultrasound.money/cfw/event"
-        src="https://ultrasound.money/cfw/script.js"
-      />
     </Head>
+    {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
+    <Script
+      defer
+      data-domain="ultrasound.money"
+      data-api="https://ultrasound.money/cfw/event"
+      src="https://ultrasound.money/cfw/script.js"
+    />
     <SWRConfig
       value={{
         fallback,

--- a/src/pages/fampreview.tsx
+++ b/src/pages/fampreview.tsx
@@ -1,6 +1,8 @@
 import type { GetStaticProps, NextPage } from "next";
+import Head from "next/head";
 import "react-loading-skeleton/dist/skeleton.css";
 import { SWRConfig } from "swr";
+import SiteMetadata from "../site-metadata";
 import type { BaseFeePerGas } from "../api/base-fee-per-gas";
 import { fetchBaseFeePerGas } from "../api/base-fee-per-gas";
 import type { BaseFeePerGasStats } from "../api/base-fee-per-gas-stats";
@@ -62,6 +64,24 @@ export const getStaticProps: GetStaticProps<StaticProps> = async () => {
 
 const WrappedFamPage: NextPage<StaticProps> = ({ fallback }) => (
   <BasicErrorBoundary>
+    <Head>
+      <meta name="description" content={SiteMetadata.description} />
+      <meta
+        name="keywords"
+        content="ultra sound money, ethereum, ETH, sound money, fee burn, EIP-1559"
+      />
+      {/* When sharing the site on twitter, twitter adds our metadata, this adds little value, so we remove it. To not spend a lot of time removing our metadata from every shared link we're disabling twitter metadata for now. */}
+      <meta property="og:title" content={SiteMetadata.title} />
+      <meta property="og:description" content={SiteMetadata.description} />
+      <meta property="og:url" content="https://ultrasound.money" />
+      {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
+      <script
+        defer
+        data-domain="ultrasound.money"
+        data-api="https://ultrasound.money/cfw/event"
+        src="https://ultrasound.money/cfw/script.js"
+      />
+    </Head>
     <SWRConfig
       value={{
         fallback,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,8 @@
 import { minutesToSeconds } from "date-fns";
 import type { GetStaticProps, NextPage } from "next";
+import Head from "next/head";
 import { SWRConfig } from "swr";
+import SiteMetadata from "../site-metadata";
 import type { BaseFeePerGas } from "../api/base-fee-per-gas";
 import { fetchBaseFeePerGas } from "../api/base-fee-per-gas";
 import type { BaseFeePerGasStats } from "../api/base-fee-per-gas-stats";
@@ -77,6 +79,24 @@ export const getStaticProps: GetStaticProps<StaticProps> = async () => {
 
 const IndexPage: NextPage<StaticProps> = ({ fallback }) => (
   <BasicErrorBoundary>
+    <Head>
+      <meta name="description" content={SiteMetadata.description} />
+      <meta
+        name="keywords"
+        content="ultra sound money, ethereum, ETH, sound money, fee burn, EIP-1559"
+      />
+      {/* When sharing the site on twitter, twitter adds our metadata, this adds little value, so we remove it. To not spend a lot of time removing our metadata from every shared link we're disabling twitter metadata for now. */}
+      <meta property="og:title" content={SiteMetadata.title} />
+      <meta property="og:description" content={SiteMetadata.description} />
+      <meta property="og:url" content="https://ultrasound.money" />
+      {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
+      <script
+        defer
+        data-domain="ultrasound.money"
+        data-api="https://ultrasound.money/cfw/event"
+        src="https://ultrasound.money/cfw/script.js"
+      />
+    </Head>
     <SWRConfig
       value={{
         fallback,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { minutesToSeconds } from "date-fns";
 import type { GetStaticProps, NextPage } from "next";
 import Head from "next/head";
+import Script from "next/script";
 import { SWRConfig } from "swr";
 import SiteMetadata from "../site-metadata";
 import type { BaseFeePerGas } from "../api/base-fee-per-gas";
@@ -89,14 +90,14 @@ const IndexPage: NextPage<StaticProps> = ({ fallback }) => (
       <meta property="og:title" content={SiteMetadata.title} />
       <meta property="og:description" content={SiteMetadata.description} />
       <meta property="og:url" content="https://ultrasound.money" />
-      {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
-      <script
-        defer
-        data-domain="ultrasound.money"
-        data-api="https://ultrasound.money/cfw/event"
-        src="https://ultrasound.money/cfw/script.js"
-      />
     </Head>
+    {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
+    <Script
+      defer
+      data-domain="ultrasound.money"
+      data-api="https://ultrasound.money/cfw/event"
+      src="https://ultrasound.money/cfw/script.js"
+    />
     <SWRConfig
       value={{
         fallback,

--- a/src/pages/relay.tsx
+++ b/src/pages/relay.tsx
@@ -1,0 +1,82 @@
+import { FC } from "react";
+import Head from "next/head";
+import * as D from "date-fns";
+import { getApiUrl } from "../relay/config";
+import BasicErrorBoundary from "../components/BasicErrorBoundary";
+import RelayDashboard, {
+  RelayDashboardProps,
+} from "../relay/components/RelayDashboard";
+
+export const getServerSideProps = async () => {
+  const apiUrl = getApiUrl();
+  const [payloads, payloadCount, validators, validatorCount] =
+    await Promise.all([
+      fetch(`${apiUrl}/api/payloads`)
+        .then((res) => res.json())
+        .then(({ payloads }) => payloads)
+        .catch((err) => {
+          console.error("error fetching payloads", err);
+          return [];
+        }),
+      fetch(`${apiUrl}/api/payloads/count`)
+        .then((res) => res.json())
+        .then(({ count }) => count)
+        .catch((err) => {
+          console.error("error fetching payload count", err);
+          return 0;
+        }),
+      fetch(`${apiUrl}/api/validators`)
+        .then((res) => res.json())
+        .then(({ validators }) => validators)
+        .catch((err) => {
+          console.error("error fetching validators", err);
+          return [];
+        }),
+      fetch(`${apiUrl}/api/validators/count`)
+        .then((res) => res.json())
+        .then(({ validatorCount }) => validatorCount)
+        .catch((err) => {
+          console.error("error fetching validator count", err);
+          return 0;
+        }),
+    ]);
+
+  return {
+    props: { payloads, payloadCount, validators, validatorCount },
+  };
+};
+
+const RelayIndexPage: FC<RelayDashboardProps> = ({
+  payloadCount,
+  payloads,
+  validatorCount,
+  validators,
+}) => {
+  const payloadsSorted = payloads
+    .map((p) => ({ ...p, insertedAt: new Date(p.insertedAt) }))
+    .sort(({ insertedAt: a }, { insertedAt: b }) => D.compareDesc(a, b));
+  const validatorsSorted = validators
+    .map((v) => ({
+      ...v,
+      insertedAt: new Date(v.insertedAt),
+    }))
+    .sort(({ insertedAt: a }, { insertedAt: b }) => D.compareDesc(a, b));
+
+  const props = {
+    payloadCount,
+    payloads: payloadsSorted,
+    validatorCount,
+    validators: validatorsSorted,
+  };
+
+  return (
+    <BasicErrorBoundary>
+      <Head>
+        <title>Ultra Sound Relay</title>
+      </Head>
+      <RelayDashboard {...props} />
+    </BasicErrorBoundary>
+  );
+};
+
+export default RelayIndexPage;

--- a/src/pages/relay.tsx
+++ b/src/pages/relay.tsx
@@ -73,6 +73,25 @@ const RelayIndexPage: FC<RelayDashboardProps> = ({
     <BasicErrorBoundary>
       <Head>
         <title>Ultra Sound Relay</title>
+        <meta property="og:title" content="Ultra Sound Relay" />
+        <meta
+          name="description"
+          content="Permissionless, neutral, and censorship free MEV relay"
+        />
+        <meta
+          name="keywords"
+          content="ultra sound relay, ethereum, ETH, MEV, MEV Boost Relay"
+        />
+        <meta
+          property="og:description"
+          content="Permissionless, neutral, and censorship free MEV relay"
+        />
+        <meta property="og:url" content="https://relay.ultrasound.money" />
+        <script
+          defer
+          data-domain="relay.ultrasound.money"
+          src="https://plausible.io/js/script.js"
+        ></script>
       </Head>
       <RelayDashboard {...props} />
     </BasicErrorBoundary>

--- a/src/pages/relay.tsx
+++ b/src/pages/relay.tsx
@@ -1,44 +1,19 @@
-import { FC } from "react";
+import type { FC } from "react";
 import Head from "next/head";
 import * as D from "date-fns";
-import { getApiUrl } from "../relay/config";
+import * as Api from "../relay/api";
 import BasicErrorBoundary from "../components/BasicErrorBoundary";
 import RelayDashboard, {
-  RelayDashboardProps,
+  type RelayDashboardProps,
 } from "../relay/components/RelayDashboard";
 
 export const getServerSideProps = async () => {
-  const apiUrl = getApiUrl();
   const [payloads, payloadCount, validators, validatorCount] =
     await Promise.all([
-      fetch(`${apiUrl}/api/payloads`)
-        .then((res) => res.json())
-        .then(({ payloads }) => payloads)
-        .catch((err) => {
-          console.error("error fetching payloads", err);
-          return [];
-        }),
-      fetch(`${apiUrl}/api/payloads/count`)
-        .then((res) => res.json())
-        .then(({ count }) => count)
-        .catch((err) => {
-          console.error("error fetching payload count", err);
-          return 0;
-        }),
-      fetch(`${apiUrl}/api/validators`)
-        .then((res) => res.json())
-        .then(({ validators }) => validators)
-        .catch((err) => {
-          console.error("error fetching validators", err);
-          return [];
-        }),
-      fetch(`${apiUrl}/api/validators/count`)
-        .then((res) => res.json())
-        .then(({ validatorCount }) => validatorCount)
-        .catch((err) => {
-          console.error("error fetching validator count", err);
-          return 0;
-        }),
+      Api.fetchPayloads(),
+      Api.fetchPayloadCount(),
+      Api.fetchValidators(),
+      Api.fetchValidatorCount(),
     ]);
 
   return {

--- a/src/pages/relay.tsx
+++ b/src/pages/relay.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import Head from "next/head";
+import Script from "next/script";
 import * as D from "date-fns";
 import * as Api from "../relay/api";
 import BasicErrorBoundary from "../components/BasicErrorBoundary";
@@ -62,12 +63,12 @@ const RelayIndexPage: FC<RelayDashboardProps> = ({
           content="Permissionless, neutral, and censorship free MEV relay"
         />
         <meta property="og:url" content="https://relay.ultrasound.money" />
-        <script
-          defer
-          data-domain="relay.ultrasound.money"
-          src="https://plausible.io/js/script.js"
-        ></script>
       </Head>
+      <Script
+        defer
+        data-domain="relay.ultrasound.money"
+        src="https://plausible.io/js/script.js"
+      />
       <RelayDashboard {...props} />
     </BasicErrorBoundary>
   );

--- a/src/pages/storypreview.tsx
+++ b/src/pages/storypreview.tsx
@@ -1,5 +1,6 @@
 import type { GetStaticProps, NextPage } from "next";
 import Head from "next/head";
+import Script from "next/script";
 import SiteMetadata from "../site-metadata";
 import { SWRConfig } from "swr";
 import type { BaseFeePerGas } from "../api/base-fee-per-gas";
@@ -66,13 +67,13 @@ const StoryPreview: NextPage<StaticProps> = ({ fallback }) => (
       <meta property="og:description" content={SiteMetadata.description} />
       <meta property="og:url" content="https://ultrasound.money" />
       {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
-      <script
-        defer
-        data-domain="ultrasound.money"
-        data-api="https://ultrasound.money/cfw/event"
-        src="https://ultrasound.money/cfw/script.js"
-      />
     </Head>
+    <Script
+      defer
+      data-domain="ultrasound.money"
+      data-api="https://ultrasound.money/cfw/event"
+      src="https://ultrasound.money/cfw/script.js"
+    />
     <SWRConfig
       value={{
         fallback,

--- a/src/pages/storypreview.tsx
+++ b/src/pages/storypreview.tsx
@@ -1,5 +1,6 @@
 import type { GetStaticProps, NextPage } from "next";
 import Head from "next/head";
+import SiteMetadata from "../site-metadata";
 import { SWRConfig } from "swr";
 import type { BaseFeePerGas } from "../api/base-fee-per-gas";
 import { fetchBaseFeePerGas } from "../api/base-fee-per-gas";
@@ -55,6 +56,22 @@ const StoryPreview: NextPage<StaticProps> = ({ fallback }) => (
   <>
     <Head>
       <title>ultrasound.money</title>
+      <meta name="description" content={SiteMetadata.description} />
+      <meta
+        name="keywords"
+        content="ultra sound money, ethereum, ETH, sound money, fee burn, EIP-1559"
+      />
+      {/* When sharing the site on twitter, twitter adds our metadata, this adds little value, so we remove it. To not spend a lot of time removing our metadata from every shared link we're disabling twitter metadata for now. */}
+      <meta property="og:title" content={SiteMetadata.title} />
+      <meta property="og:description" content={SiteMetadata.description} />
+      <meta property="og:url" content="https://ultrasound.money" />
+      {/* This serves our Plausible analytics script. We use cloudflare workers to make this possible. The name is intentionally vague as suggested in the Plausible docs. */}
+      <script
+        defer
+        data-domain="ultrasound.money"
+        data-api="https://ultrasound.money/cfw/event"
+        src="https://ultrasound.money/cfw/script.js"
+      />
     </Head>
     <SWRConfig
       value={{

--- a/src/relay/api.ts
+++ b/src/relay/api.ts
@@ -1,0 +1,50 @@
+import { getApiUrl } from "./config";
+
+export type ApiPayload = {
+  insertedAt: Date;
+  blockNumber: number;
+  value: number;
+};
+
+export type ApiValidator = {
+  insertedAt: Date;
+  pubkeyFragment: string;
+};
+
+// TODO: parse response bodies
+
+export const fetchPayloads = (): Promise<Array<ApiPayload>> =>
+  fetch(`${getApiUrl()}/api/payloads`)
+    .then((res) => res.json())
+    .then(({ payloads }) => payloads as Array<ApiPayload>)
+    .catch((err) => {
+      console.error("error fetching payloads", err);
+      return [];
+    });
+
+export const fetchPayloadCount = (): Promise<number> =>
+  fetch(`${getApiUrl()}/api/payloads/count`)
+    .then((res) => res.json())
+    .then(({ count }) => count as number)
+    .catch((err) => {
+      console.error("error fetching payload count", err);
+      return 0;
+    });
+
+export const fetchValidators = (): Promise<Array<ApiValidator>> =>
+  fetch(`${getApiUrl()}/api/validators`)
+    .then((res) => res.json())
+    .then(({ validators }) => validators as Array<ApiValidator>)
+    .catch((err) => {
+      console.error("error fetching validators", err);
+      return [];
+    });
+
+export const fetchValidatorCount = (): Promise<number> =>
+  fetch(`${getApiUrl()}/api/validators/count`)
+    .then((res) => res.json())
+    .then(({ validatorCount }) => validatorCount as number)
+    .catch((err) => {
+      console.error("error fetching validator count", err);
+      return 0;
+    });

--- a/src/relay/components/AddressWidget.tsx
+++ b/src/relay/components/AddressWidget.tsx
@@ -1,0 +1,50 @@
+import { FC, useState } from "react";
+
+import { getRelayUrl, getRelayDisplayUrl } from "../config";
+import Button from "../../components/BlueButton";
+import { WidgetBackground } from "../../components/WidgetSubcomponents";
+import LabelText from "../../components/TextsNext/LabelText";
+
+const address = getRelayUrl();
+const displayAddress = getRelayDisplayUrl();
+
+const AddressWidget: FC = () => {
+  const [copyTextVisible, setCopyTextVisible] = useState<boolean>(false);
+
+  return (
+    <WidgetBackground className="w-full">
+      <div className="flex flex-row items-center justify-between">
+        <LabelText>relay address</LabelText>
+        <p
+          className={`
+            font-inter font-light text-green-400
+            ${copyTextVisible ? "visible" : "invisible"}
+        `}
+        >
+          copied!
+        </p>
+      </div>
+      <div
+        className={`
+            mt-2 flex flex-col items-center justify-between
+            xs:flex-col sm:flex-row
+            lg:flex-col xl:flex-row
+         `}
+      >
+        <p className="mb-3 break-all font-roboto font-light text-slateus-200 lg:mb-3 xl:mb-0">
+          {displayAddress}
+        </p>
+        <div
+          onClick={() => {
+            navigator.clipboard.writeText(address);
+            setCopyTextVisible(true);
+          }}
+        >
+          <Button>copy</Button>
+        </div>
+      </div>
+    </WidgetBackground>
+  );
+};
+
+export default AddressWidget;

--- a/src/relay/components/AddressWidget.tsx
+++ b/src/relay/components/AddressWidget.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { type FC, useState } from "react";
 
 import { getRelayUrl, getRelayDisplayUrl } from "../config";
 import Button from "../../components/BlueButton";
@@ -36,7 +36,9 @@ const AddressWidget: FC = () => {
         </p>
         <div
           onClick={() => {
-            navigator.clipboard.writeText(address);
+            navigator.clipboard.writeText(address).catch((err) => {
+              console.error("failed to write to clipboard", err);
+            });
             setCopyTextVisible(true);
           }}
         >

--- a/src/relay/components/CheckRegistrationWidget.tsx
+++ b/src/relay/components/CheckRegistrationWidget.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { type FC, useState } from "react";
 
 import { getApiUrl } from "../config";
 import { WidgetBackground } from "../../components/WidgetSubcomponents";
@@ -24,6 +24,9 @@ const CheckRegistrationWidget: FC = () => {
           } else {
             setRegistrationStatus("not registered");
           }
+        })
+        .catch((err) => {
+          console.error("failed to fetch registration status", err);
         });
     }
   };

--- a/src/relay/components/CheckRegistrationWidget.tsx
+++ b/src/relay/components/CheckRegistrationWidget.tsx
@@ -1,0 +1,72 @@
+import { FC, useState } from "react";
+
+import { getApiUrl } from "../config";
+import { WidgetBackground } from "../../components/WidgetSubcomponents";
+import Button from "../../components/BlueButton";
+import LabelText from "../../components/TextsNext/LabelText";
+
+type Status = "initial" | "registered" | "not registered";
+
+const CheckRegistrationWidget: FC = () => {
+  const [addr, setAddr] = useState("");
+  const [registrationStatus, setRegistrationStatus] =
+    useState<Status>("initial");
+
+  const apiUrl = getApiUrl();
+
+  const fetchRegistrationStatus = () => {
+    if (addr.length > 0) {
+      fetch(`${apiUrl}/api/validators/${addr}`)
+        .then((res) => res.json())
+        .then(({ status }) => {
+          if (status) {
+            setRegistrationStatus("registered");
+          } else {
+            setRegistrationStatus("not registered");
+          }
+        });
+    }
+  };
+
+  return (
+    <WidgetBackground className="w-full">
+      <div className="flex flex-row items-center justify-between">
+        <LabelText>check registration</LabelText>
+        <p
+          className={`
+            font-inter font-light
+            ${registrationStatus === "initial" ? "invisible" : "visible"}
+            ${
+              registrationStatus === "registered"
+                ? "text-green-400"
+                : "text-red-400"
+            }
+        `}
+        >
+          {`${registrationStatus}!`}
+        </p>
+      </div>
+      <div className="mt-2 flex flex-row items-center justify-between">
+        <input
+          className={`
+                 mr-4 w-full rounded-full
+                 border border-slateus-500
+                 bg-slateus-800 py-1.5 pl-4
+                 font-inter text-xs font-light
+                 text-white placeholder-slateus-400 outline-none
+                 focus-within:border-slateus-400
+                 md:py-2 md:text-base
+               `}
+          placeholder="validator address"
+          value={addr}
+          onChange={(e) => setAddr(e.target.value)}
+        />
+        <div onClick={fetchRegistrationStatus}>
+          <Button>check</Button>
+        </div>
+      </div>
+    </WidgetBackground>
+  );
+};
+
+export default CheckRegistrationWidget;

--- a/src/relay/components/FaqSection.tsx
+++ b/src/relay/components/FaqSection.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import Accordion from "../../components/Accordion";
+import { SectionTitle } from "../../components/TextsNext/SectionTitle";
+import { NavigationContext } from "../../contexts/NavigationContext";
+import { calcCenterElement } from "../../utils/calcCenterElement";
+import copy from "../copy.json";
+
+const FaqBlock: React.FC = () => {
+  const { changeFaqPosition } = React.useContext(NavigationContext);
+  const faqSection = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    const resizeFun = () => {
+      if (faqSection.current) {
+        const centerBlock: number = calcCenterElement(faqSection.current);
+        changeFaqPosition(centerBlock);
+      }
+    };
+
+    resizeFun();
+    window.addEventListener("resize", resizeFun);
+
+    return () => window.removeEventListener("resize", resizeFun);
+  }, [changeFaqPosition]);
+
+  return (
+    <section
+      ref={faqSection}
+      data-aos="fade-up"
+      data-aos-anchor-placement="top-center"
+      data-aos-delay="50"
+      data-aos-duration="1000"
+      data-aos-easing="ease-in-out"
+      id="faq"
+    >
+      <div className="max-w-3xl md:m-auto md:px-4 lg:px-0 ">
+        <div className="block pb-8">
+          <SectionTitle>q&a</SectionTitle>
+        </div>
+        <div className="w-full px-4 md:px-8 lg:px-0">
+          <Accordion
+            title={copy[0]?.question as string}
+            text={copy[0]?.answer as string}
+          />
+          <div
+            className="w-full bg-slateus-400"
+            style={{ height: "1px", opacity: "0.3" }}
+          />
+          <Accordion
+            title={copy[1]?.question as string}
+            text={copy[1]?.answer as string}
+          />
+          <div
+            className="w-full bg-slateus-400"
+            style={{ height: "1px", opacity: "0.3" }}
+          />
+          <Accordion
+            title={copy[2]?.question as string}
+            text={copy[2]?.answer as string}
+          />
+          <div
+            className="w-full bg-slateus-400"
+            style={{ height: "1px", opacity: "0.3" }}
+          />
+          <Accordion
+            title={copy[3]?.question as string}
+            text={copy[3]?.answer as string}
+          />
+          <div
+            className="w-full bg-slateus-400"
+            style={{ height: "1px", opacity: "0.3" }}
+          />
+          <Accordion
+            title={copy[4]?.question as string}
+            text={copy[4]?.answer as string}
+          />
+          <div
+            className="w-full bg-slateus-400"
+            style={{ height: "1px", opacity: "0.3" }}
+          />
+          <Accordion
+            title={copy[5]?.question as string}
+            text={copy[5]?.answer as string}
+          />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FaqBlock;

--- a/src/relay/components/InclusionsWidget.tsx
+++ b/src/relay/components/InclusionsWidget.tsx
@@ -1,0 +1,97 @@
+import { FC } from "react";
+
+import * as Format from "../../format";
+import { getEtherscanUrl } from "../config";
+import scrollbarStyles from "../../styles/Scrollbar.module.scss";
+import LabelText from "../../components/TextsNext/LabelText";
+import SkeletonText from "../../components/TextsNext/SkeletonText";
+import { BaseText } from "../../components/Texts";
+import {
+  WidgetBackground,
+  WidgetTitle,
+} from "../../components/WidgetSubcomponents";
+
+const etherscanUrl = getEtherscanUrl();
+
+type Payload = {
+  blockNumber: number;
+  insertedAt: Date;
+  value: number;
+};
+
+const PayloadRow = ({ blockNumber, insertedAt, value }: Payload) => {
+  const inclusionAgo = `${Format.formatDistance(new Date(), insertedAt)} ago`;
+  const truncatedValue = value.toString().substring(0, 4);
+
+  return (
+    <a
+      key={blockNumber}
+      target="_blank"
+      href={`${etherscanUrl}/block/${blockNumber}`}
+    >
+      <li className="grid grid-cols-3 hover:opacity-60">
+        <span className="font-roboto text-white">
+          <SkeletonText width="7rem">
+            {Format.formatBlockNumber(blockNumber)}
+          </SkeletonText>
+        </span>
+        <div className="mr-1 text-right">
+          <BaseText font="font-roboto">
+            <SkeletonText width="1rem">{truncatedValue}</SkeletonText>
+          </BaseText>
+          <div className="hidden md:inline">
+            <span className="font-inter">&thinsp;</span>
+            <span className="font-roboto font-extralight text-slateus-200">
+              ETH
+            </span>
+          </div>
+        </div>
+        <div className="text-right">
+          <BaseText font="font-roboto">
+            <SkeletonText width="2rem">{inclusionAgo}</SkeletonText>
+          </BaseText>
+        </div>
+      </li>
+    </a>
+  );
+};
+
+type Props = {
+  payloadCount: number;
+  payloads: Array<Payload>;
+};
+
+const InclusionsWidget: FC<Props> = ({ payloadCount, payloads }) => (
+  <div className="flex flex-col gap-y-4">
+    <WidgetBackground>
+      <LabelText>inclusions</LabelText>
+      <p className="mt-4 text-3xl font-extralight tracking-wide">
+        <span className="font-inter text-white">{payloadCount}</span>
+        <span> </span>
+        <span className="font-roboto text-slateus-200">blocks</span>
+      </p>
+    </WidgetBackground>
+    <WidgetBackground>
+      <div className="flex flex-col gap-y-4">
+        <div className="grid grid-cols-3">
+          <WidgetTitle>block</WidgetTitle>
+          <WidgetTitle className="text-right">value</WidgetTitle>
+          <WidgetTitle className="-mr-1 text-right">inclusion</WidgetTitle>
+        </div>
+        <ul
+          className={`
+            -mr-3 flex max-h-[184px]
+            flex-col gap-y-4 overflow-y-auto
+            pr-1 md:max-h-[214px]
+            ${scrollbarStyles["styled-scrollbar-vertical"]}
+            ${scrollbarStyles["styled-scrollbar"]}
+          `}
+        >
+          {payloads.map(PayloadRow)}
+        </ul>
+      </div>
+    </WidgetBackground>
+  </div>
+);
+
+export default InclusionsWidget;

--- a/src/relay/components/InclusionsWidget.tsx
+++ b/src/relay/components/InclusionsWidget.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import type { FC } from "react";
 
 import * as Format from "../../format";
 import { getEtherscanUrl } from "../config";
@@ -27,6 +27,7 @@ const PayloadRow = ({ blockNumber, insertedAt, value }: Payload) => {
     <a
       key={blockNumber}
       target="_blank"
+      rel="noreferrer"
       href={`${etherscanUrl}/block/${blockNumber}`}
     >
       <li className="grid grid-cols-3 hover:opacity-60">

--- a/src/relay/components/RelayDashboard.tsx
+++ b/src/relay/components/RelayDashboard.tsx
@@ -1,5 +1,6 @@
-import { FC } from "react";
+import type { FC } from "react";
 
+import type { ApiPayload, ApiValidator } from "../api";
 import HeaderGlow from "../../components/HeaderGlow";
 import MainTitle from "../../components/MainTitle";
 import AddressWidget from "./AddressWidget";
@@ -8,17 +9,6 @@ import InclusionsWidget from "./InclusionsWidget";
 import ValidatorWidget from "./ValidatorWidget";
 import FaqSection from "./FaqSection";
 import ContactSection from "../../components/ContactSection";
-
-type ApiPayload = {
-  insertedAt: Date;
-  blockNumber: number;
-  value: number;
-};
-
-type ApiValidator = {
-  insertedAt: Date;
-  pubkeyFragment: string;
-};
 
 export type RelayDashboardProps = {
   payloadCount: number;

--- a/src/relay/components/RelayDashboard.tsx
+++ b/src/relay/components/RelayDashboard.tsx
@@ -1,0 +1,73 @@
+import { FC } from "react";
+
+import HeaderGlow from "../../components/HeaderGlow";
+import MainTitle from "../../components/MainTitle";
+import AddressWidget from "./AddressWidget";
+import CheckRegistrationWidget from "./CheckRegistrationWidget";
+import InclusionsWidget from "./InclusionsWidget";
+import ValidatorWidget from "./ValidatorWidget";
+import FaqSection from "./FaqSection";
+import ContactSection from "../../components/ContactSection";
+
+type ApiPayload = {
+  insertedAt: Date;
+  blockNumber: number;
+  value: number;
+};
+
+type ApiValidator = {
+  insertedAt: Date;
+  pubkeyFragment: string;
+};
+
+export type RelayDashboardProps = {
+  payloadCount: number;
+  payloads: Array<ApiPayload>;
+  validatorCount: number;
+  validators: Array<ApiValidator>;
+};
+
+const RelayDashboard: FC<RelayDashboardProps> = ({
+  payloadCount,
+  payloads,
+  validatorCount,
+  validators,
+}) => {
+  return (
+    <>
+      <HeaderGlow />
+      <div className="container mx-auto">
+        <div className="h-[48.5px] md:h-[68px]"></div>
+        <MainTitle>ultra sound relay</MainTitle>
+        <div className="mt-16 mb-32 flex flex-col gap-y-4 xs:px-4 md:px-16">
+          <div className="mt-16 flex flex-col gap-x-4 gap-y-4 lg:flex-row">
+            <div className="flex lg:w-1/2">
+              <AddressWidget />
+            </div>
+            <div className="flex lg:w-1/2">
+              <CheckRegistrationWidget />
+            </div>
+          </div>
+          <div className="flex flex-col gap-x-4 gap-y-4 lg:flex-row">
+            <div className="flex flex-col lg:w-1/2">
+              <InclusionsWidget
+                payloadCount={payloadCount}
+                payloads={payloads}
+              />
+            </div>
+            <div className="flex flex-col lg:w-1/2">
+              <ValidatorWidget
+                validatorCount={validatorCount}
+                validators={validators}
+              />
+            </div>
+          </div>
+        </div>
+        <FaqSection />
+        <ContactSection />
+      </div>
+    </>
+  );
+};
+
+export default RelayDashboard;

--- a/src/relay/components/ValidatorWidget.tsx
+++ b/src/relay/components/ValidatorWidget.tsx
@@ -1,0 +1,78 @@
+import { FC } from "react";
+
+import * as Format from "../../format";
+import scrollbarStyles from "../../styles/Scrollbar.module.scss";
+import LabelText from "../../components/TextsNext/LabelText";
+import SkeletonText from "../../components/TextsNext/SkeletonText";
+import { BaseText } from "../../components/Texts";
+import {
+  WidgetBackground,
+  WidgetTitle,
+} from "../../components/WidgetSubcomponents";
+
+type Validator = {
+  insertedAt: Date;
+  pubkeyFragment: string;
+};
+
+const ValidatorRow = ({ insertedAt, pubkeyFragment }: Validator) => {
+  const registeredAgo = `${Format.formatDistance(new Date(), insertedAt)} ago`;
+
+  return (
+    <div key={pubkeyFragment}>
+      <li className="grid grid-cols-2">
+        <div className="mr-1">
+          <BaseText font="font-roboto">
+            <SkeletonText width="1rem">{pubkeyFragment}</SkeletonText>
+          </BaseText>
+        </div>
+        <div className="text-right">
+          <BaseText font="font-roboto">
+            <SkeletonText width="2rem">{registeredAgo}</SkeletonText>
+          </BaseText>
+        </div>
+      </li>
+    </div>
+  );
+};
+
+type Props = {
+  validatorCount: number;
+  validators: Array<Validator>;
+};
+
+const ValidatorWidget: FC<Props> = ({ validatorCount, validators }) => {
+  return (
+    <div className="flex flex-col gap-y-4">
+      <WidgetBackground>
+        <LabelText>registrations</LabelText>
+        <p className="mt-4 text-3xl font-extralight tracking-wide">
+          <span className="font-inter text-white">{validatorCount}</span>
+          <span> </span>
+          <span className="font-roboto text-slateus-200">validators</span>
+        </p>
+      </WidgetBackground>
+      <WidgetBackground>
+        <div className="flex flex-col gap-y-4">
+          <div className="grid grid-cols-2">
+            <WidgetTitle>validator</WidgetTitle>
+            <WidgetTitle className="-mr-1 text-right">registration</WidgetTitle>
+          </div>
+          <ul
+            className={`
+            -mr-3 flex max-h-[184px]
+            flex-col gap-y-4 overflow-y-auto
+            pr-1 md:max-h-[214px]
+            ${scrollbarStyles["styled-scrollbar-vertical"]}
+            ${scrollbarStyles["styled-scrollbar"]}
+          `}
+          >
+            {validators.map(ValidatorRow)}
+          </ul>
+        </div>
+      </WidgetBackground>
+    </div>
+  );
+};
+
+export default ValidatorWidget;

--- a/src/relay/components/ValidatorWidget.tsx
+++ b/src/relay/components/ValidatorWidget.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import type { FC } from "react";
 
 import * as Format from "../../format";
 import scrollbarStyles from "../../styles/Scrollbar.module.scss";

--- a/src/relay/config.ts
+++ b/src/relay/config.ts
@@ -1,0 +1,44 @@
+import { getEnv } from "../config";
+
+export const getApiUrl = () => {
+  const env = getEnv();
+  return env === "stag"
+    ? "https://relay-stag.ultrasound.money"
+    : "https://relay.ultrasound.money";
+};
+
+export const getDomain = () => {
+  const env = getEnv();
+  return env === "dev" ? "http://relay.localhost:3000" : getApiUrl();
+};
+
+export const getRelayUrl = () => {
+  const env = getEnv();
+  switch (env) {
+    case "dev":
+      return "http://0xc1559cee7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay.localhost:3000";
+    case "stag":
+      return "https://0xb1559beef7b5ba3127485bbbb090362d9f497ba64e177ee2c8e7db74746306efad687f2cf8574e38d70067d40ef136dc@relay-stag.ultrasound.money";
+    case "prod":
+      return "https://0xa1559ace749633b997cb3fdacffb890aeebdb0f5a3b6aaa7eeeaf1a38af0a8fe88b9e4b1f61f236d2e64d95733327a62@relay.ultrasound.money";
+  }
+};
+
+export const getRelayDisplayUrl = () => {
+  const env = getEnv();
+  switch (env) {
+    case "dev":
+      return "http://0xc1559cee...@localhost:3000";
+    case "stag":
+      return "https://0xb1559bee...@relay-stag.ultrasound.money";
+    case "prod":
+      return "https://0xa1559ace...@relay.ultrasound.money";
+  }
+};
+
+export const getEtherscanUrl = () => {
+  const env = getEnv();
+  return env === "stag"
+    ? "https://goerli.etherscan.io"
+    : "https://etherscan.io";
+};

--- a/src/relay/copy.json
+++ b/src/relay/copy.json
@@ -1,0 +1,26 @@
+[
+    {
+        "question": "What is the ultra sound relay?",
+        "answer": "The ultra sound relay is a credibly-neutral and permissionless relay—a public good from the ultrasound.money team."
+    },
+    {
+        "question": "What is a credibly-neutral relay?",
+        "answer": "A credibly-neutral relay only validates blocks against consensus rules as in enshrined proposer-builder separation."
+    },
+    {
+        "question": "What is enshrined proposer-builder separation?",
+        "answer": "Enshrined proposer-builder separation (PBS) is an in-consensus PBS without relays, removing relay weak censorship."
+    },
+    {
+        "question": "What is weak censorship?",
+        "answer": "Weak censorship is mild transaction censorship which increases on-chain inclusion delay of censored transactions."
+    },
+    {
+        "question": "How delayed are censored transactions?",
+        "answer": "Censorship in X% of blocks yields 1/(1-X%) larger average delay. If X% = 80%, delay grows 5x from 12 sec to 1 min."
+    },
+    {
+        "question": "Anything else?",
+        "answer": "The relay operators abstain from searching and block building, and commit to self-cap the relay to 1/3 of blocks."
+    }
+]


### PR DESCRIPTION
To make component reuse possible between ultrasound.money and relay.ultrasound.money possible, this PR integrates existing relay dashboard to this repo. Here's the high level idea:

* Relay dashboard gets its own next page `relay.tsx`
* Relay specific code goes into `src/relay`. The code uses existing components and these could be moved into a `shared` dir later
* `middleware.ts` contains a redirect and a url rewrite, so that the relay page can be hosted at the root of the relay subdomain
* The `relay` subdomain is pointing to our MEV boost cluster, so we need to host a separate deployment of the frontend there

Some things to pay extra attention to:
* Make sure this change doesn't break caching / invalidate static objects in next for main site
* Make sure the middleware doesn't have any unintended consequences for main site requests
* Metadata/scripts defined in `_document.tsx` can't be overwritten by child components, so to define some data differently for the relay dashboard, i had to move those to page level. Not too happy about this, let's make sure this doesn't have any SSR or caching consequences.

There's no huge rush to merge this branch into main. I can deploy new relay dashboard features from this branch until everything checks out for main site.
