### PR TITLE
Fix 'maximumFractionDigits out of range error' when running dev version

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -43,6 +43,7 @@ export const formatOneDecimal = (num: number): string => oneDecimal.format(num);
 const usdZeroDecimals = new Intl.NumberFormat("en-US", {
   currency: "usd",
   style: "currency",
+  minimumFractionDigits: 0,
   maximumFractionDigits: 0,
 });
 


### PR DESCRIPTION
When running `yarn dev` and trying to access the page in the browser I got the below error screen:
This PR fixes this by adding a `minimumFactionDigits` value at the indicated place, as [suggested in this so post](https://stackoverflow.com/questions/41045270/range-error-with-tolocalestring-with-maximumnumber-of-digits-0). 
<img width="857" alt="image" src="https://user-images.githubusercontent.com/15629702/211244216-5ea0985e-2cb7-4d9a-b808-6e844201f27b.png">

