### PR TITLE
Fix: overflow-hidden for bg gradients

### DIFF
--- a/src/components/BaseFeesWidget.tsx
+++ b/src/components/BaseFeesWidget.tsx
@@ -263,8 +263,8 @@ const BaseFeesWidget: FC<Props> = ({
 
   return (
     <WidgetErrorBoundary title="base fees">
-      <WidgetBackground className="relative flex h-[381px] w-full flex-col">
-        <div className="pointer-events-none absolute left-0 right-0 top-0 bottom-0 overflow-hidden">
+      <WidgetBackground className="relative flex h-[381px] w-full flex-col overflow-hidden">
+        <div className="pointer-events-none absolute left-0 right-0 top-0 bottom-0">
           <div
             // will-change-transform is critical for mobile performance of rendering the chart overlayed on this element.
             className={`

--- a/src/components/BurnTotal.tsx
+++ b/src/components/BurnTotal.tsx
@@ -117,8 +117,8 @@ const BurnTotal: FC<Props> = ({ onClickTimeFrame, timeFrame, unit }) => {
 
   return (
     <WidgetErrorBoundary title="burn total">
-      <WidgetBackground className="relative">
-        <div className="pointer-events-none absolute left-0 right-0 top-0 bottom-0 overflow-hidden">
+      <WidgetBackground className="relative overflow-hidden">
+        <div className="pointer-events-none absolute left-0 right-0 top-0 bottom-0">
           <div
             className={`
               top-15

--- a/src/components/EthSupplyWidget/index.tsx
+++ b/src/components/EthSupplyWidget/index.tsx
@@ -642,8 +642,8 @@ const SupplySinceMergeWidget: FC<Props> = ({
 
   return (
     <WidgetErrorBoundary title="eth supply">
-      <WidgetBackground className="relative flex w-full flex-col">
-        <div className="pointer-events-none absolute left-0 right-0 top-0 bottom-0 overflow-hidden">
+      <WidgetBackground className="relative flex w-full flex-col overflow-hidden">
+        <div className="pointer-events-none absolute left-0 right-0 top-0 bottom-0">
           <div
             // will-change-transform is critical for mobile performance of
             // rendering the chart overlayed on this element.


### PR DESCRIPTION
## Description
- Moves the `overflow-hidden` class to the parent `div` of a few elements that use background gradients.
- Prevents background gradient from spilling outside of the rounded corners

## Related issue
- [Fixes #266]