### PR TITLE
fix: fetch relay page props concurrently

### DIFF
--- a/src/pages/relay.tsx
+++ b/src/pages/relay.tsx
@@ -48,7 +48,7 @@ type StaticProps = {
 };
 
 export const getStaticProps: GetStaticProps<StaticProps> = pipe(
-  TAlt.sequenceStructSeq({
+  TAlt.sequenceStructPar({
     builderCensorshipPerTimeFrame: fetchBuilderCensorshipPerTimeFrame,
     inclusionTimesPerTimeFrame: fetchInclusionTimesPerTimeFrame,
     lidoOperatorCensorshipPerTimeFrame: fetchLidoOperatorCensorshipPerTimeFrame,


### PR DESCRIPTION
Some of the requests are quite slow so I think we should at least fetch everything concurrently.