### PR TITLE
fix(relay-dashboard): use domain for client side requests

### DIFF
--- a/src/relay/components/CheckRegistrationWidget.tsx
+++ b/src/relay/components/CheckRegistrationWidget.tsx
@@ -13,7 +13,7 @@ const CheckRegistrationWidget: FC = () => {
   const [registrationStatus, setRegistrationStatus] =
     useState<Status>("initial");
 
-  const apiUrl = getDomain();
+  const apiUrl = getDomain(true);
 
   const fetchRegistrationStatus = () => {
     if (addr.length > 0) {

--- a/src/relay/config.ts
+++ b/src/relay/config.ts
@@ -3,7 +3,7 @@ import * as SharedConfig from "../config";
 // Inside the cluster, we need to use the k8s service name to call the api.
 // Outside the cluster, e.g. during build, we need to use the domain name.
 
-export const getDomain = (isClientSide: boolean = false) => {
+export const getDomain = (isClientSide = false) => {
   const apiEnv = SharedConfig.apiEnvFromEnv();
   const isBuild = process.env.BUILD === "true";
 

--- a/src/relay/config.ts
+++ b/src/relay/config.ts
@@ -3,7 +3,7 @@ import * as SharedConfig from "../config";
 // Inside the cluster, we need to use the k8s service name to call the api.
 // Outside the cluster, e.g. during build, we need to use the domain name.
 
-export const getDomain = () => {
+export const getDomain = (isClientSide: boolean = false) => {
   const apiEnv = SharedConfig.apiEnvFromEnv();
   const isBuild = process.env.BUILD === "true";
 
@@ -11,11 +11,13 @@ export const getDomain = () => {
     case "dev":
       return "http://relay.localhost:3000";
     case "stag":
-      return isBuild
+      return isBuild || isClientSide
         ? "https://relay-stag.ultrasound.money"
         : "http://website-api";
     case "prod":
-      return isBuild ? "https://relay.ultrasound.money" : "http://website-api";
+      return isBuild || isClientSide
+        ? "https://relay.ultrasound.money"
+        : "http://website-api";
   }
 };
 


### PR DESCRIPTION
Fix using k8s service name as host for the one client side call in the relay dashboard. 