### PR TITLE
feat(EthSupplyProjection): Dynamic default values for sliders

### DIFF
--- a/src/components/SliderMarkers.tsx
+++ b/src/components/SliderMarkers.tsx
@@ -5,9 +5,9 @@ import { TimeFrameText } from "./Texts";
 import Twemoji from "./Twemoji";
 import * as Format from "../format";
 
-type SliderMarker = { label: string; value: number };
+export type SliderMarker = { label: string; value: number };
 
-const SliderMarkers: FC<{
+export const SliderMarkers: FC<{
   markerList: SliderMarker[];
   min: number;
   max: number;

--- a/src/components/SliderMarkers.tsx
+++ b/src/components/SliderMarkers.tsx
@@ -7,6 +7,9 @@ import * as Format from "../format";
 
 export type SliderMarker = { label: string; value: number };
 
+// Minimum percentage difference between markers to avoid overlap
+const MIN_PERCENTAGE_DIFFERENCE = 5;
+
 export const SliderMarkers: FC<{
   markerList: SliderMarker[];
   min: number;
@@ -15,7 +18,7 @@ export const SliderMarkers: FC<{
   const range = max - min;
   const shownList = markerList.reduce((list: SliderMarker[], marker) => {
     const someConflict = list.some(
-      (shownMarker) => Math.abs(shownMarker.value - marker.value) < 0.0017,
+      (shownMarker) => Math.abs(shownMarker.value - marker.value) < ((max - min) * MIN_PERCENTAGE_DIFFERENCE / 100),
     );
 
     if (someConflict) {

--- a/src/components/SliderMarkers.tsx
+++ b/src/components/SliderMarkers.tsx
@@ -1,0 +1,65 @@
+import * as DateFns from "date-fns";
+import _last from "lodash/last";
+import type { FC } from "react";
+import { TimeFrameText } from "./Texts";
+import Twemoji from "./Twemoji";
+import * as Format from "../format";
+
+type SliderMarker = { label: string; value: number };
+
+const SliderMarkers: FC<{
+  markerList: SliderMarker[];
+  min: number;
+  max: number;
+}> = ({ markerList, min, max }) => {
+  const range = max - min;
+  const shownList = markerList.reduce((list: SliderMarker[], marker) => {
+    const someConflict = list.some(
+      (shownMarker) => Math.abs(shownMarker.value - marker.value) < 0.0017,
+    );
+
+    if (someConflict) {
+      return list;
+    }
+
+    return [...list, marker];
+  }, []);
+
+  return (
+    <>
+      {shownList.map((marker, index) => {
+        const percent = ((marker.value - min) / range) * 100;
+        return (
+          <div
+            key={marker.label}
+            className={`
+              absolute top-[14px] flex
+              -translate-x-1/2 flex-col items-center
+            `}
+            // Positions the marker along the track whilst compensating for the thumb width as the browser natively does. 7 being half the thumb width.
+            style={{
+              left: `calc(${percent}% - ${((percent / 100) * 2 - 1) * 7}px)`,
+            }}
+          >
+            <div
+              className={`
+                -mt-0.5 w-0.5 rounded-b-full bg-slateus-200
+                ${index % 2 === 0 ? "h-2" : "h-6"}
+              `}
+            ></div>
+            <TimeFrameText className="mt-1 select-none text-slateus-200">
+              <Twemoji
+                className="flex gap-x-1"
+                imageClassName="mt-0.5 h-3"
+                wrapper
+              >
+                {marker.label}
+              </Twemoji>
+            </TimeFrameText>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+export default SliderMarkers;

--- a/src/mainsite/components/EquilibriumWidget/index.tsx
+++ b/src/mainsite/components/EquilibriumWidget/index.tsx
@@ -5,7 +5,7 @@ import type { FC } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { TimeFrameText } from "../../../components/Texts";
 import BodyText from "../../../components/TextsNext/BodyText";
-import Twemoji from "../../../components/Twemoji";
+import SliderMarkers from "../../../components/SliderMarkers";
 import WidgetErrorBoundary from "../../../components/WidgetErrorBoundary";
 import {
   WidgetBackground,
@@ -84,7 +84,6 @@ const STAKING_RANGE = STAKING_MAX - STAKING_MIN;
 
 const BURN_RATE_MIN = 0.0;
 const BURN_RATE_MAX = 0.03;
-const BURN_RATE_RANGE = BURN_RATE_MAX - BURN_RATE_MIN;
 
 type BurnMarkers = {
   all: number;
@@ -93,10 +92,8 @@ type BurnMarkers = {
   d7: number;
   d1: number;
 };
-type BurnMarker = { label: string; value: number };
-
 const BurnMarkers: FC<{ burnMarkers?: BurnMarkers }> = ({ burnMarkers }) => {
-  const markerList: BurnMarker[] =
+  const markerList =
     burnMarkers !== undefined
       ? [
           { label: "all", value: burnMarkers.all },
@@ -107,54 +104,12 @@ const BurnMarkers: FC<{ burnMarkers?: BurnMarkers }> = ({ burnMarkers }) => {
         ]
       : [];
 
-  const shownList = markerList.reduce((list: BurnMarker[], marker) => {
-    const someConflict = list.some(
-      (shownMarker) => Math.abs(shownMarker.value - marker.value) < 0.0017,
-    );
-
-    if (someConflict) {
-      return list;
-    }
-
-    return [...list, marker];
-  }, []);
-
   return (
-    <>
-      {shownList.map((marker, index) => {
-        const percent =
-          ((marker.value - BURN_RATE_MIN) / BURN_RATE_RANGE) * 100;
-        return (
-          <div
-            key={marker.label}
-            className={`
-              absolute top-[14px] flex
-              -translate-x-1/2 flex-col items-center
-            `}
-            // Positions the marker along the track whilst compensating for the thumb width as the browser natively does. 7 being half the thumb width.
-            style={{
-              left: `calc(${percent}% - ${((percent / 100) * 2 - 1) * 7}px)`,
-            }}
-          >
-            <div
-              className={`
-                -mt-0.5 w-0.5 rounded-b-full bg-slateus-200
-                ${index % 2 === 0 ? "h-2" : "h-6"}
-              `}
-            ></div>
-            <TimeFrameText className="mt-1 select-none text-slateus-200">
-              <Twemoji
-                className="flex gap-x-1"
-                imageClassName="mt-0.5 h-3"
-                wrapper
-              >
-                {marker.label}
-              </Twemoji>
-            </TimeFrameText>
-          </div>
-        );
-      })}
-    </>
+    <SliderMarkers
+      markerList={markerList}
+      min={BURN_RATE_MIN}
+      max={BURN_RATE_MAX}
+    />
   );
 };
 
@@ -439,7 +394,7 @@ const EquilibriumWidget = () => {
           </div>
           <div className="flex flex-col gap-y-7">
             <div>
-              <div className="flex justify-between items-baseline">
+              <div className="flex items-baseline justify-between">
                 <div className="flex items-center truncate">
                   <WidgetTitle>issuance rewards</WidgetTitle>
                   <BodyText className="invisible text-xs md:text-xs lg:visible">
@@ -482,7 +437,7 @@ const EquilibriumWidget = () => {
                     }px)`,
                   }}
                 >
-                  <div className="-mt-0.5 w-0.5 h-2 rounded-b-full bg-slateus-200"></div>
+                  <div className="-mt-0.5 h-2 w-0.5 rounded-b-full bg-slateus-200"></div>
                   <TimeFrameText className="mt-0.5 text-slateus-200">
                     now
                   </TimeFrameText>
@@ -490,7 +445,7 @@ const EquilibriumWidget = () => {
               </div>
             </div>
             <div>
-              <div className="flex justify-between items-baseline">
+              <div className="flex items-baseline justify-between">
                 <div className="flex items-center truncate">
                   <WidgetTitle>burn rate</WidgetTitle>
                   <BodyText className="text-xs md:text-xs">
@@ -520,7 +475,7 @@ const EquilibriumWidget = () => {
             </div>
           </div>
 
-          <div className="flex flex-col justify-between items-baseline mt-2 -mb-2 w-full md:flex-row">
+          <div className="mt-2 -mb-2 flex w-full flex-col items-baseline justify-between md:flex-row">
             <WidgetTitle>issuance and burn at equilibrium</WidgetTitle>
             <MoneyAmount amountPostfix="K" unitText="ETH/year">
               {equilibriums !== undefined

--- a/src/mainsite/components/TwoYearProjection/index.tsx
+++ b/src/mainsite/components/TwoYearProjection/index.tsx
@@ -174,7 +174,7 @@ const TwoYearProjection: FC = () => {
             />
             <div
               className={`
-                  relative top-[14px] flex
+                  relative  flex
                   -translate-x-1/2 select-none flex-col
                   items-center
                   ${
@@ -222,7 +222,7 @@ const TwoYearProjection: FC = () => {
             />
             <div
               className={`
-                  relative top-[14px] flex
+                  relative flex
                   -translate-x-1/2 select-none flex-col
                   items-center
                   ${

--- a/src/mainsite/components/TwoYearProjection/index.tsx
+++ b/src/mainsite/components/TwoYearProjection/index.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 import TranslationsContext from "../../contexts/TranslationsContext";
 import { formatOneDecimal } from "../../../format";
+import { GWEI_PER_ETH, Gwei } from "../../../eth-units";
 import {
   estimatedDailyFeeBurn,
   estimatedDailyIssuance,
@@ -10,7 +11,8 @@ import { BaseText } from "../../../components/Texts";
 import Twemoji from "../../../components/Twemoji";
 import styles from "./TwoYearProjection.module.scss";
 import type { ChangeEvent, FC, ReactNode } from "react";
-import { useCallback, useState, useContext } from "react";
+import { useCallback, useEffect, useState, useContext } from "react";
+import { useEffectiveBalanceSum } from "../../api/effective-balance-sum";
 const SupplyChart = dynamic(() => import("./TwoYearProjectionChart"));
 
 const MIN_PROJECTED_ETH_STAKING = 1e6;
@@ -64,12 +66,54 @@ const TwoYearProjection: FC = () => {
     setIsPeakPresent(isPeakPresent);
   }, []);
 
+  const [stakingAprFraction, setStakingAprFraction] = useState<number>(0);
+  const BASE_REWARD_FACTOR = 64;
+  const SECONDS_PER_SLOT = 12;
+  const SLOTS_PER_EPOCH = 32;
+  const EPOCHS_PER_DAY: number =
+    (24 * 60 * 60) / SLOTS_PER_EPOCH / SECONDS_PER_SLOT;
+  const EPOCHS_PER_YEAR: number = 365.25 * EPOCHS_PER_DAY;
+  const MAX_EFFECTIVE_BALANCE: number = 32 * GWEI_PER_ETH;
+  const BASE_REWARDS_PER_EPOCH = 4;
+
+  const getIssuanceApr = (effective_balance_sum: Gwei): number => {
+    const balance_sum_gwei = effective_balance_sum;
+    const max_issuance_per_epoch = Math.trunc(
+      (BASE_REWARD_FACTOR * balance_sum_gwei) /
+        Math.floor(Math.sqrt(balance_sum_gwei)),
+    );
+    const issuancePerYear = max_issuance_per_epoch * EPOCHS_PER_YEAR;
+    const apr = issuancePerYear / balance_sum_gwei;
+    return apr;
+  };
+
+  const getStakedFromApr = (apr: number): number => {
+    const baseReward = (apr * 32e9) / 4 / EPOCHS_PER_YEAR;
+    const active_validators =
+      ((MAX_EFFECTIVE_BALANCE * BASE_REWARD_FACTOR) /
+        BASE_REWARDS_PER_EPOCH /
+        baseReward) **
+        2 /
+      32e9;
+    return active_validators * 32;
+  };
+
+  const effectiveBalanceSum = useEffectiveBalanceSum();
+
+  useEffect(() => {
+    if (effectiveBalanceSum === undefined) {
+      return;
+    }
+    const initialStakingApr = getIssuanceApr(effectiveBalanceSum.sum);
+    setStakingAprFraction(initialStakingApr);
+  }, [effectiveBalanceSum, stakingAprFraction]);
+
   return (
     <>
       <div className={styles.chartHeader}>
         <BaseText
           font="font-inter"
-          className="flex items-center px-3 pb-8 text-xs tracking-widest uppercase text-slateus-200"
+          className="flex items-center px-3 pb-8 text-xs uppercase tracking-widest text-slateus-200"
           inline
         >
           ETH supply—2y projection
@@ -97,7 +141,7 @@ const TwoYearProjection: FC = () => {
           title={t.eth_staked}
           value={
             <>
-              {projectedStaking / 1e6}
+              {getStakedFromApr(stakingAprFraction) / 1e6}
               {t.numeric_million_abbrev} ETH
             </>
           }

--- a/src/mainsite/components/TwoYearProjection/index.tsx
+++ b/src/mainsite/components/TwoYearProjection/index.tsx
@@ -32,7 +32,6 @@ const TwoYearProjection: FC = () => {
   const [projectedStaking, setProjectedStaking] = useState(
     DEFAULT_PROJECTED_ETH_STAKING,
   );
-  // TODO Initialize this to current base gas price
   const [projectedBaseGasPrice, setProjectedBaseGasPrice] = useState(
     DEFAULT_PROJECTED_BASE_GAS_PRICE,
   );
@@ -42,6 +41,7 @@ const TwoYearProjection: FC = () => {
   const handleProjectedStakingChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       setProjectedStaking(parseInt(e.target.value));
+      setUserHasAdjustedStakedEth(true);
     },
     [],
   );
@@ -49,6 +49,7 @@ const TwoYearProjection: FC = () => {
   const handleProjectedBaseGasPriceChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       setProjectedBaseGasPrice(parseInt(e.target.value));
+      setUserHasAdjustedBaseFee(true);
     },
     [],
   );
@@ -68,7 +69,9 @@ const TwoYearProjection: FC = () => {
 
   const effectiveBalanceSum = useEffectiveBalanceSum();
   const baseFeesOverTime = useBaseFeeOverTime();
-  const [isInitialized, setIsInitialized] = useState(false);
+  const [userHasAdjustedStakedEth, setUserHasAdjustedStakedEth] =
+    useState(false);
+  const [userHasAdjustedBaseFee, setUserHasAdjustedBaseFee] = useState(false);
   const [currentStakedEth, setCurrentStakedEth] = useState<number | undefined>(
     undefined,
   );
@@ -92,17 +95,15 @@ const TwoYearProjection: FC = () => {
       : undefined;
 
   useEffect(() => {
-    if (
-      isInitialized ||
-      effectiveBalanceSum === undefined ||
-      baseFeesOverTime === undefined
-    ) {
+    if (effectiveBalanceSum === undefined || baseFeesOverTime === undefined) {
       return;
     }
     const intialStakingAmount = Math.round(effectiveBalanceSum.sum / 1e9);
     console.log("intialStakingAmount", intialStakingAmount);
     setCurrentStakedEth(intialStakingAmount);
-    setProjectedStaking(intialStakingAmount);
+    if (!userHasAdjustedStakedEth) {
+      setProjectedStaking(intialStakingAmount);
+    }
     console.log("baseFeesOverTime:", baseFeesOverTime);
     const latestBaseFee =
       baseFeesOverTime.m5[baseFeesOverTime.m5.length - 1]?.wei;
@@ -110,8 +111,9 @@ const TwoYearProjection: FC = () => {
       return;
     }
     setCurrentBaseFee(latestBaseFee / 1e9);
-    setProjectedBaseGasPrice(latestBaseFee / 1e9);
-    setIsInitialized(true);
+    if (!userHasAdjustedBaseFee) {
+      setProjectedBaseGasPrice(latestBaseFee / 1e9);
+    }
   }, [baseFeesOverTime, effectiveBalanceSum]);
 
   return (

--- a/src/mainsite/components/TwoYearProjection/index.tsx
+++ b/src/mainsite/components/TwoYearProjection/index.tsx
@@ -149,7 +149,7 @@ const TwoYearProjection: FC = () => {
           title={t.eth_staked}
           value={
             <>
-              {formatOneDecimal(projectedStaking / 1e6)}
+              {Math.round(projectedStaking / 1e6)}
               {t.numeric_million_abbrev} ETH
             </>
           }
@@ -202,7 +202,7 @@ const TwoYearProjection: FC = () => {
 
         <Param
           title={t.base_gas_price}
-          value={<>{formatOneDecimal(projectedBaseGasPrice)} Gwei</>}
+          value={<>{Math.round(projectedBaseGasPrice)} Gwei</>}
           subValue={
             <>
               {t.fee_burn}

--- a/src/mainsite/components/TwoYearProjection/index.tsx
+++ b/src/mainsite/components/TwoYearProjection/index.tsx
@@ -13,6 +13,7 @@ import type { ChangeEvent, FC, ReactNode } from "react";
 import { useCallback, useEffect, useState, useContext } from "react";
 import { useBaseFeeOverTime } from "../../api/base-fee-over-time";
 import { useEffectiveBalanceSum } from "../../api/effective-balance-sum";
+import { TimeFrameText } from "../../../components/Texts";
 const SupplyChart = dynamic(() => import("./TwoYearProjectionChart"));
 
 const MIN_PROJECTED_ETH_STAKING = 1e6;
@@ -71,6 +72,12 @@ const TwoYearProjection: FC = () => {
   const [currentStakedEth, setCurrentStakedEth] = useState<number | undefined>(
     undefined,
   );
+
+  const currentStakedEthPercent =
+    currentStakedEth !== undefined
+      ? ((currentStakedEth - MIN_PROJECTED_ETH_STAKING) / MAX_PROJECTED_ETH_STAKING) * 100
+      : undefined;
+
   const [currentBaseFee, setCurrentBaseFee] = useState<number | undefined>(
     undefined,
   );
@@ -146,15 +153,36 @@ const TwoYearProjection: FC = () => {
             </>
           }
         >
-          <Slider
-            min={MIN_PROJECTED_ETH_STAKING}
-            max={MAX_PROJECTED_ETH_STAKING}
-            value={projectedStaking}
-            step={1e6}
-            onChange={handleProjectedStakingChange}
-            onPointerDown={handleProjectedStakingPointerDown}
-            onPointerUp={handleProjectedStakingPointerUp}
-          />
+          <div className="relative z-10">
+            <Slider
+              min={MIN_PROJECTED_ETH_STAKING}
+              max={MAX_PROJECTED_ETH_STAKING}
+              value={projectedStaking}
+              step={1e6}
+              onChange={handleProjectedStakingChange}
+              onPointerDown={handleProjectedStakingPointerDown}
+              onPointerUp={handleProjectedStakingPointerUp}
+            />
+            <div
+              className={`
+                  relative top-[14px] flex
+                  -translate-x-1/2 select-none flex-col
+                  items-center
+                  ${currentStakedEthPercent === undefined ? "invisible" : "visible"}
+                `}
+              style={{
+                // Positions the marker along the track whilst compensating for the thumb width as the browser natively does. 7 being half the thumb width.
+                left: `calc(${currentStakedEthPercent}% - ${
+                  (((currentStakedEthPercent ?? 0) / 100) * 2 - 1) * 7
+                }px)`,
+              }}
+            >
+              <div className="-mt-0.5 h-2 w-0.5 rounded-b-full bg-slateus-200"></div>
+              <TimeFrameText className="mt-0.5 text-slateus-200">
+                now
+              </TimeFrameText>
+            </div>
+          </div>
         </Param>
 
         <Param

--- a/src/mainsite/components/TwoYearProjection/index.tsx
+++ b/src/mainsite/components/TwoYearProjection/index.tsx
@@ -75,12 +75,21 @@ const TwoYearProjection: FC = () => {
 
   const currentStakedEthPercent =
     currentStakedEth !== undefined
-      ? ((currentStakedEth - MIN_PROJECTED_ETH_STAKING) / MAX_PROJECTED_ETH_STAKING) * 100
+      ? ((currentStakedEth - MIN_PROJECTED_ETH_STAKING) /
+          MAX_PROJECTED_ETH_STAKING) *
+        100
       : undefined;
 
   const [currentBaseFee, setCurrentBaseFee] = useState<number | undefined>(
     undefined,
   );
+
+  const currentBaseFeePercent =
+    currentBaseFee !== undefined
+      ? ((currentBaseFee - MIN_PROJECTED_BASE_GAS_PRICE) /
+          MAX_PROJECTED_BASE_GAS_PRICE) *
+        100
+      : undefined;
 
   useEffect(() => {
     if (
@@ -168,7 +177,11 @@ const TwoYearProjection: FC = () => {
                   relative top-[14px] flex
                   -translate-x-1/2 select-none flex-col
                   items-center
-                  ${currentStakedEthPercent === undefined ? "invisible" : "visible"}
+                  ${
+                    currentStakedEthPercent === undefined
+                      ? "invisible"
+                      : "visible"
+                  }
                 `}
               style={{
                 // Positions the marker along the track whilst compensating for the thumb width as the browser natively does. 7 being half the thumb width.
@@ -199,13 +212,38 @@ const TwoYearProjection: FC = () => {
             </>
           }
         >
-          <Slider
-            min={MIN_PROJECTED_BASE_GAS_PRICE}
-            max={MAX_PROJECTED_BASE_GAS_PRICE}
-            value={projectedBaseGasPrice}
-            step={1}
-            onChange={handleProjectedBaseGasPriceChange}
-          />
+          <div className="relative z-10">
+            <Slider
+              min={MIN_PROJECTED_BASE_GAS_PRICE}
+              max={MAX_PROJECTED_BASE_GAS_PRICE}
+              value={projectedBaseGasPrice}
+              step={1}
+              onChange={handleProjectedBaseGasPriceChange}
+            />
+            <div
+              className={`
+                  relative top-[14px] flex
+                  -translate-x-1/2 select-none flex-col
+                  items-center
+                  ${
+                    currentBaseFeePercent === undefined
+                      ? "invisible"
+                      : "visible"
+                  }
+                `}
+              style={{
+                // Positions the marker along the track whilst compensating for the thumb width as the browser natively does. 7 being half the thumb width.
+                left: `calc(${currentBaseFeePercent}% - ${
+                  (((currentBaseFeePercent ?? 0) / 100) * 2 - 1) * 7
+                }px)`,
+              }}
+            >
+              <div className="-mt-0.5 h-2 w-0.5 rounded-b-full bg-slateus-200"></div>
+              <TimeFrameText className="mt-0.5 text-slateus-200">
+                now
+              </TimeFrameText>
+            </div>
+          </div>
         </Param>
       </div>
     </>


### PR DESCRIPTION
closes: https://github.com/ultrasoundmoney/frontend/issues/298

- [x] Make sure user choice is never overwritten
- [x] Investigate slight offset between now marker and initial slider position (probably because of slider step)
- [x] Explore options to make decimal precision and slider step consistent
- [x] Change base fee markers from "now" to "all", "30d", "ultrasound"
