### PR TITLE
chore: update early contributors segment order

### DIFF
--- a/src/mainsite/components/IssuanceBreakdown.tsx
+++ b/src/mainsite/components/IssuanceBreakdown.tsx
@@ -203,19 +203,6 @@ const IssuanceBreakdown = () => {
             <div className="w-0.5 h-2 bg-slateus-500"></div>
             <CategorySegment
               imgAlt={
-                "a seedling symbolizing the gardening Ethereum Foundation"
-              }
-              imgName={"seedling"}
-              onHoverCategory={setHighlightEthereumFoundation}
-              percentOfTotalRewards={getPercentOfTotal(
-                issuanceBreakdown,
-                "ethereumFoundation",
-              )}
-              showHighlight={highlightEthereumFoundation}
-            />
-            <div className="w-0.5 h-2 bg-slateus-500"></div>
-            <CategorySegment
-              imgAlt={
                 "a unicorn symbolizing the early contributors dreaming up and building Ethereum"
               }
               imgName={"unicorn"}
@@ -225,6 +212,19 @@ const IssuanceBreakdown = () => {
                 "earlyContributors",
               )}
               showHighlight={highlightEarlyContributors}
+            />
+            <div className="w-0.5 h-2 bg-slateus-500"></div>
+            <CategorySegment
+              imgAlt={
+                "a seedling symbolizing the gardening Ethereum Foundation"
+              }
+              imgName={"seedling"}
+              onHoverCategory={setHighlightEthereumFoundation}
+              percentOfTotalRewards={getPercentOfTotal(
+                issuanceBreakdown,
+                "ethereumFoundation",
+              )}
+              showHighlight={highlightEthereumFoundation}
             />
             <div className="w-0.5 h-2 bg-slateus-500"></div>
             <CategorySegment


### PR DESCRIPTION
* Updates the segment's order in issuance breakdown (early contributors should be at third position)
* Closes #307.

<img width="732" alt="Bildschirmfoto 2024-02-14 um 13 45 14" src="https://github.com/ultrasoundmoney/frontend/assets/2104965/ec8d5240-f19d-443c-b7b7-99a4b4e54177">
