### PR TITLE
Fix: href to unexistent google finance page

### DIFF
--- a/src/mainsite/components/PriceModel.tsx
+++ b/src/mainsite/components/PriceModel.tsx
@@ -78,7 +78,7 @@ const Marker: FC<MarkerProps> = ({ alt, icon, peRatio, symbol }) => {
             ? undefined
             : symbol === "DIS"
             ? "https://www.google.com/finance/quote/DIS:NYSE"
-            : symbol === "ETH
+            : symbol === "ETH"
             ? `https://www.google.com/finance/quote/ETH-USD`
             : `https://www.google.com/finance/quote/${symbol}:NASDAQ`
         }


### PR DESCRIPTION
Fixed the link on the priceModel component, it was redirecting to ETH:NASDAQ, while the correct one should be ETH-USD.