### PR TITLE
fix: make burn and issuance timeframe consistent and legible

### DIFF
--- a/src/mainsite/components/PriceModel.tsx
+++ b/src/mainsite/components/PriceModel.tsx
@@ -308,8 +308,8 @@ const PriceModel: FC = () => {
   const gaugeRates = useGaugeRates();
   const initialPeRatioSet = useRef<boolean>(false);
 
-  const annualizedRevenue = gaugeRates.since_burn.burn_rate_yearly.usd;
-  const annualizedCosts = gaugeRates.d7.issuance_rate_yearly.usd;
+  const annualizedRevenue = gaugeRates.h1.burn_rate_yearly.usd;
+  const annualizedCosts = gaugeRates.h1.issuance_rate_yearly.usd;
   const annualizedEarnings =
     annualizedRevenue === undefined || annualizedCosts === undefined
       ? undefined

--- a/src/mainsite/components/PriceModelTooltip.tsx
+++ b/src/mainsite/components/PriceModelTooltip.tsx
@@ -34,10 +34,13 @@ const PriceModelTooltip: FC<{
     <BodyTextV3 className="font-semibold">price model</BodyTextV3>
     <WidgetTitle>formula</WidgetTitle>
     <BodyTextV3 className="whitespace-pre-wrap md:leading-normal">
-      profits = revenue (burn) - expenses (issuance)
+      profits* = revenue (burn) - expenses (issuance)
     </BodyTextV3>
     <BodyTextV3 className="whitespace-pre-wrap md:leading-normal">
       price = profits * P/E ratio * monetary premium
+    </BodyTextV3>
+    <BodyTextV3 className="whitespace-pre-wrap md:leading-normal">
+      * annaulized based on last 6mo
     </BodyTextV3>
   </div>
 );


### PR DESCRIPTION
Think timeframes for burn/issuance should be consistent as generally that's what's expected in standard reporting. Also added a small disclaimer in the tooltip to ensure that folks know that it's based on last 6 months of data annualized as opposed to d7 for issuance and since burn for burn. I would use trailing 1yr data but don't see it in the `/api/v2/fees/gauge-rates` response. 

If H1 is just considering H1 as opposed to last 6 months might be worthwhile to add support for trailing 1yr via the backend.