### PR TITLE
Base Fees: Extend tooltip to include burned and issued ETH (#303)

### DIFF
--- a/src/mainsite/sections/GasSection.tsx
+++ b/src/mainsite/sections/GasSection.tsx
@@ -35,7 +35,7 @@ const GasSection: FC<{
 }> = ({ timeFrame, onClickTimeFrame }) => {
   const baseFeesOverTime = useBaseFeeOverTime();
 
-  const [baseFeesSeries, max] = useMemo(() => {
+  const [baseFeesSeries, max, burnedIssuedMap] = useMemo(() => {
     if (baseFeesOverTime === undefined) {
       return [undefined, undefined];
     }
@@ -47,8 +47,16 @@ const GasSection: FC<{
         : pointsFromBaseFeesOverTime(baseFeesOverTimeTimeFrame);
 
     const max = _maxBy(series, (point) => point[1]);
-
-    return [series, max];
+    const burnedIssued =
+      baseFeesOverTimeTimeFrame === undefined
+        ? undefined
+        : Object.fromEntries(
+            baseFeesOverTimeTimeFrame.map(({ timestamp, wei }) => [
+              parseISO(timestamp).getTime(),
+              wei,
+            ]),
+          );
+    return [series, max, burnedIssued];
   }, [baseFeesOverTime, timeFrame]);
 
   const baseFeesMap =
@@ -67,6 +75,7 @@ const GasSection: FC<{
             max={max?.[1]}
             timeFrame={timeFrame}
             onClickTimeFrame={onClickTimeFrame}
+            burnedIssuedMap={burnedIssuedMap}
           />
         </div>
         <div className="flex w-full flex-col gap-y-4 lg:w-1/2">


### PR DESCRIPTION
### Description
This PR fixes the `BaseFeesWidget` tooltip to correctly display burned ETH when the base fee is below the ultra sound barrier, addressing the issue where it showed "0.00 ETH issued" (e.g., on May 9, 2025, with a base fee of 7.98 Gwei vs. a barrier of 53.3 Gwei).

### Changes
- Added `burnedIssuedMap` prop to `BaseFeesWidget` to include net ETH change (issuance minus burn) data.
- Updated `GasSection` to compute `burnedIssuedMap` from `useBaseFeeOverTime` data and pass it to `BaseFeesWidget`.
- Modified `BaseFeesWidget` tooltip logic to display "X.XX ETH burned" when `netEthChange` is negative.
- Ensured the tooltip handles `netEthChange = 0` cases appropriately.

### Related Issue
Closes #303

Before:
![296935235-0f13e5ce-e759-4a81-900b-2d5f77ef46d8](https://github.com/user-attachments/assets/b6806f1c-189e-4fe4-9b5c-f35a6152aa98)

After:
<img width="468" alt="Screenshot 2025-05-14 at 11 17 36 PM" src="https://github.com/user-attachments/assets/1c870374-e649-4a3b-89d1-671d17bfb7ed" />

