### PR TITLE
Dev

### DIFF
--- a/src/mainsite/components/BaseFeesWidget.tsx
+++ b/src/mainsite/components/BaseFeesWidget.tsx
@@ -16,6 +16,8 @@ import TimeFrameIndicator from "../components/TimeFrameIndicator";
 import type { TimeFrame } from "../time-frames";
 import type { OnClick } from "../../components/TimeFrameControl";
 
+// BaseFeesWidget component for displaying Ethereum base fee data
+
 export type BaseFeePoint = [JsTimestamp, Gwei];
 
 // Somehow resolves an error thrown by the annotation lib


### PR DESCRIPTION
This PR addresses the issue where the gas price chart's left axis always displayed a minimum value of at least 10 gwei, regardless of actual data. While the barrier toggle functionality was working as intended, the chart did not dynamically adjust its axis, leading to potential misrepresentation of lower gas prices.

Changes made:

    Removed the fixed minimum limit of 10 gwei on the left axis.

    Updated the chart axis scaling logic to dynamically adapt based on the dataset.

    Ensured barrier toggle functionality remains unaffected and fully operational.

Impact:

    The chart now accurately reflects the full range of gas prices, including values above 10 gwei whether barrier is hidden or not.

    Provides a clearer and more precise visualization for users, especially when gas prices are low.

This fix enhances the user experience by ensuring the chart's Y-axis accurately matches the data range without artificial constraints.


<img width="834" height="598" alt="Screenshot (91)" src="https://github.com/user-attachments/assets/6f8142da-68ee-403e-ac1c-4a56fe2da5d5" />
<img width="830" height="564" alt="Screenshot (90)" src="https://github.com/user-attachments/assets/74cc189f-67e4-43a9-8905-e09ed9a99fe2" />
