### PR TITLE
Adds validator costs widget

### DIFF
--- a/src/mainsite/api/validator-costs.ts
+++ b/src/mainsite/api/validator-costs.ts
@@ -1,0 +1,145 @@
+import { useEthPriceStats } from "./eth-price-stats";
+import { useValidatorRewards, getTotalAnnualReward, getTotalApr } from "./validator-rewards";
+import { GWEI_PER_ETH } from "../../eth-units";
+
+export type ValidatorCosts = {
+  hardware: {
+    annualCostUsd: number;
+    annualCostEth: number;
+    aprImpact: number;
+    assumptions: string;
+  };
+  internet: {
+    annualCostUsd: number;
+    annualCostEth: number;
+    aprImpact: number;
+    assumptions: string;
+  };
+  power: {
+    annualCostUsd: number;
+    annualCostEth: number;
+    aprImpact: number;
+    assumptions: string;
+  };
+  totalCostsUsd: number;
+  totalCostsEth: number;
+  netRewardsEth: number;
+  netRewardsUsd: number;
+  grossRewardsEth: number;
+  grossRewardsUsd: number;
+  grossApr: number;
+  netApr: number;
+  costRatio: number;
+};
+
+/**
+ * Annual validator operating costs in USD
+ * Based on typical home staking setup costs
+ */
+const HARDWARE_COST_USD = 200; // $800 setup amortized over 4 years
+const INTERNET_COST_USD = 300; // $25/month reliable connection
+const POWER_COST_USD = 60; // 50W * 8760h * $0.13/kWh (US average)
+
+/** Standard Ethereum validator stake requirement */
+const VALIDATOR_STAKE_ETH = 32;
+
+export type CostToggleState = {
+  hardware: boolean;
+  internet: boolean;
+  power: boolean;
+};
+
+/**
+ * Hook to calculate validator operating costs and net profitability
+ * @param enabledCosts - Optional toggle state for each cost category
+ * @returns Validator cost data including gross/net rewards, APR impacts, and cost ratios
+ */
+export const useValidatorCosts = (enabledCosts?: CostToggleState): ValidatorCosts | undefined => {
+  const validatorRewards = useValidatorRewards();
+  const ethPriceStats = useEthPriceStats();
+
+  // Default all costs to enabled if not specified
+  const costState = enabledCosts ?? { hardware: true, internet: true, power: true };
+
+  // Calculate costs if we have both validator rewards and ETH price
+  if (!validatorRewards || !ethPriceStats) {
+    return undefined;
+  }
+
+  const ethPriceUsd = ethPriceStats.usd;
+  
+  // Early return if ETH price is invalid or zero
+  if (!ethPriceUsd || ethPriceUsd <= 0) {
+    return undefined;
+  }
+
+  // Convert annual rewards from GWEI to ETH
+  const grossRewardsGwei = getTotalAnnualReward(validatorRewards) ?? 0;
+  const grossRewardsEth = grossRewardsGwei / GWEI_PER_ETH;
+  
+  // Get gross APR from validator rewards
+  const grossApr = getTotalApr(validatorRewards) ?? 0;
+
+  // Convert USD costs to ETH (apply toggle state)
+  const hardwareCostEth = costState.hardware ? HARDWARE_COST_USD / ethPriceUsd : 0;
+  const internetCostEth = costState.internet ? INTERNET_COST_USD / ethPriceUsd : 0;
+  const powerCostEth = costState.power ? POWER_COST_USD / ethPriceUsd : 0;
+  
+  const totalCostsUsd = 
+    (costState.hardware ? HARDWARE_COST_USD : 0) + 
+    (costState.internet ? INTERNET_COST_USD : 0) + 
+    (costState.power ? POWER_COST_USD : 0);
+  const totalCostsEth = totalCostsUsd / ethPriceUsd;
+  
+  // Calculate APR impact for each cost (cost / 32 ETH stake * 100)
+  const hardwareAprImpact = (hardwareCostEth / VALIDATOR_STAKE_ETH) * 100;
+  const internetAprImpact = (internetCostEth / VALIDATOR_STAKE_ETH) * 100;
+  const powerAprImpact = (powerCostEth / VALIDATOR_STAKE_ETH) * 100;
+  
+  const netRewardsEth = grossRewardsEth - totalCostsEth;
+  const netApr = grossApr - ((totalCostsEth / VALIDATOR_STAKE_ETH) * 100);
+  const costRatio = grossRewardsEth > 0 ? (totalCostsEth / grossRewardsEth) * 100 : 0;
+  
+  // Calculate USD values for gross and net rewards
+  const grossRewardsUsd = grossRewardsEth * ethPriceUsd;
+  const netRewardsUsd = netRewardsEth * ethPriceUsd;
+
+  return {
+    hardware: {
+      annualCostUsd: HARDWARE_COST_USD,
+      annualCostEth: HARDWARE_COST_USD / ethPriceUsd, // Always show base cost
+      aprImpact: hardwareAprImpact, 
+      assumptions: "Hardware depreciated over 4 years. Based on budget setup (~$800)",
+    },
+    internet: {
+      annualCostUsd: INTERNET_COST_USD,
+      annualCostEth: INTERNET_COST_USD / ethPriceUsd, // Always show base cost
+      aprImpact: internetAprImpact,
+      assumptions: "Reliable home internet connection. Estimated $25/month",
+    },
+    power: {
+      annualCostUsd: POWER_COST_USD,
+      annualCostEth: POWER_COST_USD / ethPriceUsd, // Always show base cost
+      aprImpact: powerAprImpact,
+      assumptions: "50W continuous power at $0.13/kWh (US average). ~438 kWh/year",
+    },
+    totalCostsUsd,
+    totalCostsEth,
+    netRewardsEth,
+    netRewardsUsd,
+    grossRewardsEth,
+    grossRewardsUsd,
+    grossApr,
+    netApr,
+    costRatio,
+  };
+};
+
+export const getCostRatioColor = (costRatio: number | undefined): string => {
+  if (typeof costRatio !== 'number' || !isFinite(costRatio) || costRatio < 0) {
+    return "#8899A6"; // Gray - invalid/loading state
+  }
+  if (costRatio <= 5) return "#00ffa3"; // Green - healthy
+  if (costRatio <= 10) return "#f4900c"; // Yellow - acceptable  
+  return "#ef4444"; // Red - concerning
+};

--- a/src/mainsite/components/ValidatorCostsWidget.tsx
+++ b/src/mainsite/components/ValidatorCostsWidget.tsx
@@ -1,0 +1,300 @@
+import type { FC } from "react";
+import Skeleton from "react-loading-skeleton";
+import {
+  useValidatorCosts,
+  getCostRatioColor,
+  type CostToggleState,
+} from "../api/validator-costs";
+import * as Format from "../../format";
+import { MoneyAmount, PercentAmount } from "./Amount";
+import BodyText from "../../components/TextsNext/BodyText";
+import LabelText from "../../components/TextsNext/LabelText";
+import {
+  WidgetBackground,
+  WidgetTitle,
+} from "../../components/WidgetSubcomponents";
+import { useState, useCallback } from "react";
+import { BaseText } from "../../components/Texts";
+
+type SimpleTooltipProps = {
+  children: React.ReactNode;
+  text: string | undefined;
+};
+
+const SimpleTooltip: FC<SimpleTooltipProps> = ({ children, text }) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  if (!text) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      className="relative isolate"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      onFocus={() => setShowTooltip(true)}
+      onBlur={() => setShowTooltip(false)}
+    >
+      <div
+        className={`
+          absolute left-0 bottom-8 w-72 z-50
+          rounded-lg border border-slateus-400 bg-slateus-700 p-3
+          ${showTooltip ? "block" : "hidden"}
+        `}
+        style={{
+          opacity: '1',
+          isolation: 'isolate'
+        }}
+      >
+        <BaseText font="font-inter" color="text-slateus-300" size="text-xs">
+          {text}
+        </BaseText>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+type CostRowProps = {
+  name: string;
+  costEth: number | undefined;
+  costUsd: number | undefined;
+  aprImpact: number | undefined;
+  assumptions: string | undefined;
+  emoji: string;
+  isEnabled: boolean;
+  onToggle: () => void;
+};
+
+const CostRow: FC<CostRowProps> = ({
+  name,
+  costEth,
+  costUsd,
+  aprImpact,
+  assumptions,
+  emoji,
+  isEnabled,
+  onToggle,
+}) => (
+  <div 
+    className={`grid grid-cols-4 items-center gap-x-2 md:gap-x-3 cursor-pointer transition-all duration-200 hover:bg-slateus-700/20 rounded-lg px-2 py-1 -mx-2 ${
+      !isEnabled ? 'opacity-40 bg-slateus-800/20' : ''
+    }`}
+    onClick={onToggle}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onToggle();
+      }
+    }}
+    role="button"
+    tabIndex={0}
+    aria-label={`${name} cost: ${isEnabled ? 'enabled' : 'disabled'}. Click to ${isEnabled ? 'disable' : 'enable'}.`}
+    title={isEnabled ? 'Click to disable this cost' : 'Click to enable this cost'}
+  >
+    <div className="flex items-center gap-x-2">
+      <SimpleTooltip text={assumptions}>
+        <div className="flex items-center gap-x-2 cursor-help">
+          <span 
+            className={`text-base flex-shrink-0 ${!isEnabled ? 'grayscale' : ''}`}
+            style={{ filter: !isEnabled ? 'grayscale(1)' : 'none' }}
+          >
+            {emoji}
+          </span>
+          <BodyText className="truncate">{name}</BodyText>
+        </div>
+      </SimpleTooltip>
+    </div>
+    <MoneyAmount className="font-light text-right">
+      {costEth === undefined
+        ? undefined
+        : isEnabled ? Format.formatTwoDigit(costEth) : Format.formatTwoDigit(0)}
+    </MoneyAmount>
+    <BodyText className="text-right text-slateus-400 text-xs">
+      {costUsd === undefined
+        ? <Skeleton width="2rem" />
+        : isEnabled ? `$${Format.formatZeroDecimals(costUsd)}` : '$0'}
+    </BodyText>
+    <PercentAmount className="text-right text-red-400">
+      {aprImpact === undefined
+        ? undefined
+        : isEnabled ? `-${Format.formatPercentTwoDecimals(aprImpact / 100)}` : '-0.00%'}
+    </PercentAmount>
+  </div>
+);
+
+type CostRatioIndicatorProps = {
+  costRatio: number | undefined;
+};
+
+const CostRatioIndicator: FC<CostRatioIndicatorProps> = ({
+  costRatio,
+}) => {
+  if (costRatio === undefined) {
+    return (
+      <div className="flex flex-col items-end gap-y-1">
+        <Skeleton height="0.75rem" width="4rem" />
+        <Skeleton height="1.5rem" width="3rem" />
+      </div>
+    );
+  }
+
+  const color = getCostRatioColor(costRatio);
+
+  return (
+    <div className="flex flex-col items-end gap-y-1">
+      <BodyText className="text-slateus-400 text-xs uppercase tracking-wider">
+        cost ratio
+      </BodyText>
+      <div
+        className="text-xl md:text-2xl font-roboto font-light"
+        style={{ color }}
+      >
+        {Format.formatOneDecimal(costRatio)}%
+      </div>
+    </div>
+  );
+};
+
+const ValidatorCostsWidget: FC = () => {
+  const [enabledCosts, setEnabledCosts] = useState<CostToggleState>({
+    hardware: true,
+    internet: true,
+    power: true,
+  });
+
+  const validatorCosts = useValidatorCosts(enabledCosts);
+
+  const toggleCost = useCallback((costType: keyof CostToggleState) => {
+    setEnabledCosts(prev => ({
+      ...prev,
+      [costType]: !prev[costType],
+    }));
+  }, []);
+
+  return (
+    <WidgetBackground>
+      <div className="flex flex-row justify-between items-start mb-6">
+        <WidgetTitle>validator costs</WidgetTitle>
+        <SimpleTooltip text="How much of a solo stakers rewards are offset by costs. Delegating stake costs from 5% to 15% on average.">
+          <div className="cursor-help">
+            <CostRatioIndicator costRatio={validatorCosts?.costRatio} />
+          </div>
+        </SimpleTooltip>
+      </div>
+      
+      <div className="flex flex-col gap-y-4">
+        {/* Cost Breakdown Header */}
+        <div className="grid grid-cols-4 gap-x-2 md:gap-x-3">
+          <LabelText>category</LabelText>
+          <LabelText className="text-right">ETH/year</LabelText>
+          <LabelText className="text-right hidden sm:block">USD/year</LabelText>
+          <LabelText className="text-right sm:hidden">USD</LabelText>
+          <LabelText className="text-right">APR impact</LabelText>
+        </div>
+
+        {/* Cost Rows */}
+        <div className="flex flex-col gap-y-3">
+          <CostRow
+            name="hardware"
+            costEth={validatorCosts?.hardware.annualCostEth}
+            costUsd={validatorCosts?.hardware.annualCostUsd}
+            aprImpact={validatorCosts?.hardware.aprImpact}
+            assumptions={validatorCosts?.hardware.assumptions}
+            emoji="💻"
+            isEnabled={enabledCosts.hardware}
+            onToggle={() => toggleCost('hardware')}
+          />
+          <CostRow
+            name="internet"
+            costEth={validatorCosts?.internet.annualCostEth}
+            costUsd={validatorCosts?.internet.annualCostUsd}
+            aprImpact={validatorCosts?.internet.aprImpact}
+            assumptions={validatorCosts?.internet.assumptions}
+            emoji="📶"
+            isEnabled={enabledCosts.internet}
+            onToggle={() => toggleCost('internet')}
+          />
+          <CostRow
+            name="power"
+            costEth={validatorCosts?.power.annualCostEth}
+            costUsd={validatorCosts?.power.annualCostUsd}
+            aprImpact={validatorCosts?.power.aprImpact}
+            assumptions={validatorCosts?.power.assumptions}
+            emoji="⚡"
+            isEnabled={enabledCosts.power}
+            onToggle={() => toggleCost('power')}
+          />
+          
+          <hr className="h-[1px] border-slateus-400" />
+          
+          {/* Gross Rewards */}
+          <div className="grid grid-cols-4 items-center gap-x-2">
+            <BodyText className="text-slateus-300">gross rewards</BodyText>
+            <MoneyAmount className="text-right text-slateus-300">
+              {validatorCosts?.grossRewardsEth === undefined
+                ? undefined
+                : Format.formatTwoDigit(validatorCosts.grossRewardsEth)}
+            </MoneyAmount>
+            <BodyText className="text-right text-slateus-400 text-xs">
+              {validatorCosts?.grossRewardsUsd === undefined
+                ? <Skeleton width="2rem" />
+                : `$${Format.formatZeroDecimals(validatorCosts.grossRewardsUsd)}`}
+            </BodyText>
+            <PercentAmount className="text-right text-slateus-300">
+              {validatorCosts?.grossApr === undefined
+                ? undefined
+                : Format.formatOneDecimal(validatorCosts.grossApr)}%
+            </PercentAmount>
+          </div>
+          
+          {/* Total Costs */}
+          <div className="grid grid-cols-4 items-center gap-x-2">
+            <BodyText>total costs</BodyText>
+            <MoneyAmount className="text-right">
+              {validatorCosts?.totalCostsEth === undefined
+                ? undefined
+                : Format.formatTwoDigit(validatorCosts.totalCostsEth)}
+            </MoneyAmount>
+            <BodyText className="text-right text-slateus-400 text-xs">
+              {validatorCosts?.totalCostsUsd === undefined
+                ? <Skeleton width="2rem" />
+                : `$${Format.formatZeroDecimals(validatorCosts.totalCostsUsd)}`}
+            </BodyText>
+            <PercentAmount className="text-right text-red-400">
+              {validatorCosts === undefined
+                ? undefined
+                : `-${Format.formatPercentTwoDecimals((validatorCosts.totalCostsEth / 32))}`}
+            </PercentAmount>
+          </div>
+
+          <hr className="h-[1px] border-slateus-400" />
+
+          {/* Net Rewards */}
+          <div className="grid grid-cols-4 items-center gap-x-2 font-semibold">
+            <BodyText>net rewards</BodyText>
+            <MoneyAmount className="text-right">
+              {validatorCosts?.netRewardsEth === undefined
+                ? undefined
+                : Format.formatTwoDigit(validatorCosts.netRewardsEth)}
+            </MoneyAmount>
+            <BodyText className="text-right text-slateus-400 text-xs">
+              {validatorCosts?.netRewardsUsd === undefined
+                ? <Skeleton width="2rem" />
+                : `$${Format.formatZeroDecimals(validatorCosts.netRewardsUsd)}`}
+            </BodyText>
+            <PercentAmount className="text-right">
+              {validatorCosts?.netApr === undefined
+                ? undefined
+                : Format.formatOneDecimal(validatorCosts.netApr)}%
+            </PercentAmount>
+          </div>
+        </div>
+
+      </div>
+    </WidgetBackground>
+  );
+};
+
+export default ValidatorCostsWidget;

--- a/src/mainsite/sections/MonetaryPremiumSection.tsx
+++ b/src/mainsite/sections/MonetaryPremiumSection.tsx
@@ -18,11 +18,11 @@ const MonetaryPremiumSection: FC = () => (
         <ScarcityWidget />
         <ValidatorRewardsWidget />
         <ValidatorCostsWidget />
-        <Flippenings />
       </div>
       <div className="flex basis-1/2 flex-col gap-y-4">
         <PriceModel />
         <IssuanceBreakdown />
+        <Flippenings />
       </div>
     </div>
   </Section>

--- a/src/mainsite/sections/MonetaryPremiumSection.tsx
+++ b/src/mainsite/sections/MonetaryPremiumSection.tsx
@@ -4,6 +4,7 @@ import IssuanceBreakdown from "../components/IssuanceBreakdown";
 import PriceModel from "../components/PriceModel";
 import ScarcityWidget from "../components/ScarcityWidget";
 import ValidatorRewardsWidget from "../components/ValidatorRewards";
+import ValidatorCostsWidget from "../components/ValidatorCostsWidget";
 import Section from "../../components/Section";
 
 const MonetaryPremiumSection: FC = () => (
@@ -16,6 +17,7 @@ const MonetaryPremiumSection: FC = () => (
       <div className="flex basis-1/2 flex-col gap-y-4">
         <ScarcityWidget />
         <ValidatorRewardsWidget />
+        <ValidatorCostsWidget />
         <Flippenings />
       </div>
       <div className="flex basis-1/2 flex-col gap-y-4">


### PR DESCRIPTION
## Problem to be solved

Most analysis of Ethereum staking assumes the cost of operation to be zero. This is not true. Even with conserative, low cost assumptions, including valuing the operator's labour at 0, the costs outweigh the alternatives such as delegated staking. 

## Proposed solution

In an effort to increase awareness of the costs of staking, this PR adds a basic overview of the costs of solo staking, including a comparison to delegation in the form of a cost ratio. 

<img width="658" height="793" alt="Screenshot 2025-09-01 at 11 49 35" src="https://github.com/user-attachments/assets/bdf879cf-5ab9-4f2a-9416-8f72118dfaf3" />


This PR may need some refinement before merging, including getting icons more inline with the website style. It could also be extended to show more expensive forms of staking such as using bare metal or cloud providers or squad staking setups, it could be extended to show how cost ratios come down with more and more eth to solo stake, etc. Feedback welcome :) 