### PR TITLE
fix(blob-gas-gwei-threshold) Decrease blob gas gwei threshold

### DIFF
--- a/src/mainsite/components/BlobGasMarketWidget.tsx
+++ b/src/mainsite/components/BlobGasMarketWidget.tsx
@@ -12,7 +12,7 @@ import type { TimeFrame } from "../time-frames";
 import TimeFrameIndicator from "./TimeFrameIndicator";
 import type { OnClick } from "../../components/TimeFrameControl";
 
-const GWEI_FORMATTING_THRESHOLD = 100_000_000; // Threshold in wei above which to convert to / format as Gwei
+const GWEI_FORMATTING_THRESHOLD = 1_000_000; // Threshold in wei above which to convert to / format as Gwei
 
 const getPercentage = (
   highest: number,


### PR DESCRIPTION
Currently the blob gas gwei threshold is 0.1 which results in some very high wei values displayed on the website. This commit decreases the threshold to 0.001 so values displayed on the website are easier to read.